### PR TITLE
Remove `std::fmt::Debug` from `AuthUser` requirements

### DIFF
--- a/src/auth_user.rs
+++ b/src/auth_user.rs
@@ -38,7 +38,7 @@
 /// assert_eq!(user.get_password_hash(), "hunter42".to_string());
 /// # }
 /// ```
-pub trait AuthUser: std::fmt::Debug + Clone + Send + Sync + 'static {
+pub trait AuthUser: Clone + Send + Sync + 'static {
     /// Returns the ID of the user.
     ///
     /// This is used to generate the user ID for the session. We assume this

--- a/src/user_store.rs
+++ b/src/user_store.rs
@@ -5,7 +5,7 @@ use crate::{AuthUser, Result};
 /// A trait which defines a method that allows retrieval of users from an
 /// arbitrary backend.
 #[async_trait]
-pub trait UserStore: std::fmt::Debug + Clone + Send + Sync + 'static {
+pub trait UserStore: Clone + Send + Sync + 'static {
     /// An associated user type which will be loaded from the store.
     type User: AuthUser;
 


### PR DESCRIPTION
This PR fixes #6 and improves the `password_hash` security hygiene.