### PR TITLE
Add an example to require a special user field value

### DIFF
--- a/examples/memory/Cargo.toml
+++ b/examples/memory/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 axum = "0.5.13"
 axum-login = { path = "../../" }
+async-trait = "0.1.58"
 
 [dependencies.rand]
 version = "0.8.5"


### PR DESCRIPTION
This simple example shows how to check additional field values to support some basic permission checks.

Closes #8.