### PR TITLE
WIP: Implement basic RBAC support

### DIFF
--- a/examples/memory/src/main.rs
+++ b/examples/memory/src/main.rs
@@ -22,11 +22,17 @@ use axum_login::{
 use rand::Rng;
 use tokio::sync::RwLock;
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
+enum Role {
+    User,
+    Admin,
+}
+
+#[derive(Debug, Clone)]
 struct User {
     id: usize,
     password_hash: String,
-    is_admin: bool,
+    role: Role,
     name: String,
 }
 
@@ -35,12 +41,13 @@ impl User {
         Self {
             id: 1,
             name: "Ferris the Crab".to_string(),
-            ..Default::default()
+            password_hash: "password".to_string(),
+            role: Role::Admin,
         }
     }
 }
 
-impl AuthUser for User {
+impl AuthUser<Role> for User {
     fn get_id(&self) -> String {
         format!("{}", self.id)
     }
@@ -48,11 +55,16 @@ impl AuthUser for User {
     fn get_password_hash(&self) -> String {
         self.password_hash.clone()
     }
+
+    fn get_role(&self) -> Option<Role> {
+        Some(self.role.clone())
+    }
 }
 
 /// Example how to create an Admin user guard
 /// Can be modified to support any type of permission
 struct RequireAdmin(User);
+struct RequireUser(User);
 
 #[async_trait]
 impl<B> FromRequest<B> for RequireAdmin
@@ -66,15 +78,41 @@ where
             .await
             .map_err(|_err| StatusCode::FORBIDDEN)?;
 
-        if !user.is_admin {
-            Err(StatusCode::FORBIDDEN)
-        } else {
+        if user
+            .get_role()
+            .map_or(false, |role| matches!(role, Role::Admin))
+        {
             Ok(RequireAdmin(user))
+        } else {
+            Err(StatusCode::FORBIDDEN)
         }
     }
 }
 
-type AuthContext = axum_login::extractors::AuthContext<User, AuthMemoryStore<User>>;
+#[async_trait]
+impl<B> FromRequest<B> for RequireUser
+where
+    B: Send + 'static,
+{
+    type Rejection = StatusCode;
+
+    async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
+        let Extension(user): Extension<User> = Extension::from_request(req)
+            .await
+            .map_err(|_err| StatusCode::FORBIDDEN)?;
+
+        if user
+            .get_role()
+            .map_or(false, |role| matches!(role, Role::User))
+        {
+            Ok(RequireUser(user))
+        } else {
+            Err(StatusCode::FORBIDDEN)
+        }
+    }
+}
+
+type AuthContext = axum_login::extractors::AuthContext<User, AuthMemoryStore<User>, Role>;
 
 #[tokio::main]
 async fn main() {
@@ -108,10 +146,15 @@ async fn main() {
         format!("Admin logged in as: {}", user.name)
     }
 
+    async fn user_handler(RequireUser(user): RequireUser) -> impl IntoResponse {
+        format!("User logged in as: {}", user.name)
+    }
+
     let app = Router::new()
         .route("/protected", get(protected_handler))
         .route("/protected_admin", get(admin_handler))
-        .route_layer(RequireAuthorizationLayer::<User>::login())
+        .route("/protected_user", get(user_handler))
+        .route_layer(RequireAuthorizationLayer::<User, Role>::login())
         .route("/login", get(login_handler))
         .route("/logout", get(logout_handler))
         .layer(auth_layer)

--- a/src/auth_user.rs
+++ b/src/auth_user.rs
@@ -17,7 +17,13 @@
 ///     password_hash: String,
 /// }
 ///
-/// impl AuthUser for MyUser {
+/// #[derive(Debug, Clone)]
+/// enum Role {
+///     User,
+///     Admin,
+/// }
+///
+/// impl AuthUser<Role> for MyUser {
 ///     fn get_id(&self) -> String {
 ///         format!("{}", self.id)
 ///     }
@@ -38,7 +44,10 @@
 /// assert_eq!(user.get_password_hash(), "hunter42".to_string());
 /// # }
 /// ```
-pub trait AuthUser: Clone + Send + Sync + 'static {
+pub trait AuthUser<Role = ()>: Clone + Send + Sync + 'static
+where
+    Role: Clone + Send + Sync + 'static,
+{
     /// Returns the ID of the user.
     ///
     /// This is used to generate the user ID for the session. We assume this
@@ -50,4 +59,11 @@ pub trait AuthUser: Clone + Send + Sync + 'static {
     /// This is used to generate a unique auth ID for the session. Note that a
     /// password hash changing will cause the session to become invalidated.
     fn get_password_hash(&self) -> String;
+
+    /// Returns the role assigned to the given user.
+    ///
+    /// This is used when specifying role requirements for handlers.
+    fn get_role(&self) -> Option<Role> {
+        None
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,11 +55,18 @@
 //! use rand::Rng;
 //! use tokio::sync::RwLock;
 //!
-//! #[derive(Debug, Default, Clone)]
+//! #[derive(Debug, Clone)]
 //! struct User {
 //!     id: usize,
 //!     name: String,
 //!     password_hash: String,
+//!     role: Role
+//! }
+//!
+//! #[derive(Debug, Clone)]
+//! enum Role {
+//!     User,
+//!     Admin,
 //! }
 //!
 //! impl User {
@@ -67,12 +74,13 @@
 //!         Self {
 //!             id: 1,
 //!             name: "Ferris the Crab".to_string(),
-//!             ..Default::default()
+//!             password_hash: "password".to_string(),
+//!             role: Role::Admin,
 //!         }
 //!     }
 //! }
 //!
-//! impl AuthUser for User {
+//! impl AuthUser<Role> for User {
 //!     fn get_id(&self) -> String {
 //!         format!("{}", self.id)
 //!     }
@@ -80,9 +88,13 @@
 //!     fn get_password_hash(&self) -> String {
 //!         self.password_hash.clone()
 //!     }
+//!
+//!     fn get_role(&self) -> Option<Role> {
+//!         Some(self.role.clone())
+//!     }
 //! }
 //!
-//! type Auth = AuthContext<User, AuthMemoryStore<User>>;
+//! type Auth = AuthContext<User, AuthMemoryStore<User>, Role>;
 //!
 //! #[tokio::main]
 //! async fn main() {
@@ -114,7 +126,7 @@
 //!
 //!     let app = Router::new()
 //!         .route("/", get(protected_handler))
-//!         .route_layer(RequireAuthorizationLayer::<User>::login())
+//!         .route_layer(RequireAuthorizationLayer::<User, Role>::login())
 //!         .route("/login", get(login_handler))
 //!         .route("/logout", get(logout_handler))
 //!         .layer(auth_layer)

--- a/src/memory_store.rs
+++ b/src/memory_store.rs
@@ -33,9 +33,10 @@ impl<User> MemoryStore<User> {
 }
 
 #[async_trait]
-impl<User> UserStore for MemoryStore<User>
+impl<User, Role> UserStore<Role> for MemoryStore<User>
 where
-    User: AuthUser,
+    Role: Clone + Send + Sync + 'static,
+    User: AuthUser<Role>,
 {
     type User = User;
 

--- a/src/user_store.rs
+++ b/src/user_store.rs
@@ -5,9 +5,12 @@ use crate::{AuthUser, Result};
 /// A trait which defines a method that allows retrieval of users from an
 /// arbitrary backend.
 #[async_trait]
-pub trait UserStore: Clone + Send + Sync + 'static {
+pub trait UserStore<Role>: Clone + Send + Sync + 'static
+where
+    Role: Clone + Send + Sync + 'static,
+{
     /// An associated user type which will be loaded from the store.
-    type User: AuthUser;
+    type User: AuthUser<Role>;
 
     /// Load and return a user.
     ///


### PR DESCRIPTION
Roles are optional and backwards-compatible.

Closes #11

@maxcountryman I did a basic implementation, can you check if this is good enough to be merged? Take into account that I may be rather bad at Rust so bugs/errors/other problems may happen although I tested both the forward as well as backward compatibility.

Since we have the `get_role()` method now we can possibly create a generic `Extractor` to verify roles. Should this be implemented in this task or a different one?