### PR TITLE
basic tower test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ homepage = "https://github.com/maxcountryman/axum-login"
 license = "MIT"
 keywords = ["sessions", "authentication", "authorization", "login", "axum"]
 categories = [
-  "web-programming::http-server",
-  "web-programming",
-  "database",
-  "asynchronous",
+    "web-programming::http-server",
+    "web-programming",
+    "database",
+    "asynchronous",
 ]
 repository = "https://github.com/maxcountryman/axum-login"
 
@@ -40,6 +40,10 @@ tokio = { version = "1.20.1", features = ["sync"] }
 tower = "0.4.13"
 tower-http = { version = "0.3.4", features = ["auth"] }
 tracing = "0.1.36"
+
+[dev-dependencies]
+http = "0.2.8"
+hyper = "0.14.23"
 
 [dev-dependencies.rand]
 version = "0.8.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 //!     id: usize,
 //!     name: String,
 //!     password_hash: String,
-//!     role: Role
+//!     role: Role,
 //! }
 //!
 //! #[derive(Debug, Clone)]


### PR DESCRIPTION
This introduces a basic test utilizing Tower directly. In order to facilitate Tower, some changes are made to the body type signature. This should be backwards compatible and means that this library is accessible outside the direct context of Axum.