### PR TITLE
Implement a role-based `RequireAuthorizationLayer`

### DIFF
--- a/examples/login-with-role/Cargo.toml
+++ b/examples/login-with-role/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "example-login-with-role"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+axum = "0.5.13"
+axum-login = { path = "../../" }
+async-trait = "0.1.58"
+
+[dependencies.rand]
+version = "0.8.5"
+features = ["min_const_gen"]
+
+[dependencies.tokio]
+version = "1.0"
+features = ["full"]

--- a/examples/simple-with-role/Cargo.toml
+++ b/examples/simple-with-role/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "example-simple-with-role"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+axum = "0.5.13"
+axum-login = { path = "../../" }
+async-trait = "0.1.58"
+
+[dependencies.rand]
+version = "0.8.5"
+features = ["min_const_gen"]
+
+[dependencies.tokio]
+version = "1.0"
+features = ["full"]

--- a/src/auth_user.rs
+++ b/src/auth_user.rs
@@ -17,7 +17,7 @@
 ///     password_hash: String,
 /// }
 ///
-/// #[derive(Debug, Clone)]
+/// #[derive(Debug, Clone, PartialEq)]
 /// enum Role {
 ///     User,
 ///     Admin,
@@ -46,7 +46,7 @@
 /// ```
 pub trait AuthUser<Role = ()>: Clone + Send + Sync + 'static
 where
-    Role: Clone + Send + Sync + 'static,
+    Role: PartialEq + Clone + Send + Sync + 'static,
 {
     /// Returns the ID of the user.
     ///

--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -48,7 +48,7 @@ impl<User, Store, Role> AuthContext<User, Store, Role>
 where
     User: AuthUser<Role>,
     Store: UserStore<Role, User = User>,
-    Role: Clone + Send + Sync + 'static,
+    Role: PartialEq + Clone + Send + Sync + 'static,
 {
     fn get_session_auth_id(&self, password_hash: &str) -> String {
         let tag = hmac::sign(&self.key, password_hash.as_bytes());
@@ -126,7 +126,7 @@ where
 #[async_trait]
 impl<Body, User, Store, Role> FromRequest<Body> for AuthContext<User, Store, Role>
 where
-    Role: Clone + Send + Sync + 'static,
+    Role: PartialEq + Clone + Send + Sync + 'static,
     Body: Send,
     User: AuthUser<Role>,
     Store: UserStore<Role, User = User>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@
 //!     role: Role,
 //! }
 //!
-//! #[derive(Debug, Clone)]
+//! #[derive(Debug, Clone, PartialEq)]
 //! enum Role {
 //!     User,
 //!     Admin,

--- a/src/memory_store.rs
+++ b/src/memory_store.rs
@@ -35,7 +35,7 @@ impl<User> MemoryStore<User> {
 #[async_trait]
 impl<User, Role> UserStore<Role> for MemoryStore<User>
 where
-    Role: Clone + Send + Sync + 'static,
+    Role: PartialEq + Clone + Send + Sync + 'static,
     User: AuthUser<Role>,
 {
     type User = User;

--- a/src/sqlx_store.rs
+++ b/src/sqlx_store.rs
@@ -45,7 +45,7 @@ macro_rules! impl_user_store {
         #[async_trait]
         impl<User, Role> UserStore<Role> for $store<User, Role>
         where
-            Role: Clone + Send + Sync + 'static,
+            Role: PartialEq + Clone + Send + Sync + 'static,
             User: AuthUser<Role> + Unpin + for<'r> FromRow<'r, $row>,
         {
             type User = User;

--- a/src/user_store.rs
+++ b/src/user_store.rs
@@ -7,7 +7,7 @@ use crate::{AuthUser, Result};
 #[async_trait]
 pub trait UserStore<Role>: Clone + Send + Sync + 'static
 where
-    Role: Clone + Send + Sync + 'static,
+    Role: PartialEq + Clone + Send + Sync + 'static,
 {
     /// An associated user type which will be loaded from the store.
     type User: AuthUser<Role>;


### PR DESCRIPTION
The new implementation allows to specify a role requirement for a given handler.

Closes #14.