### PR TITLE
Implement `PartialOrd` for `Role`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ sqlx = ["sqlx/runtime-tokio-rustls"]
 [dependencies]
 async-trait = "0.1.57"
 axum = "0.5.15"
-axum-sessions = "0.3.1"
+axum-sessions = "0.3"
 base64 = "0.13.0"
 eyre = "0.6.8"
 futures = "0.3.21"
@@ -41,6 +41,7 @@ tokio = { version = "1.20.1", features = ["sync"] }
 tower = "0.4.13"
 tower-http = { version = "0.3.4", features = ["auth"] }
 tracing = "0.1.36"
+dyn-clone = "1.0.9"
 
 [dev-dependencies]
 http = "0.2.8"

--- a/examples/login-with-role/src/main.rs
+++ b/examples/login-with-role/src/main.rs
@@ -22,7 +22,7 @@ use axum_login::{
 use rand::Rng;
 use tokio::sync::RwLock;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
 enum Role {
     User,
     Admin,
@@ -96,7 +96,7 @@ async fn main() {
     }
 
     async fn user_handler(Extension(user): Extension<User>) -> impl IntoResponse {
-        format!("User logged in as: {}", user.name)
+        format!("Admin or user logged in as: {}", user.name)
     }
 
     let app = Router::new()

--- a/examples/memory/Cargo.toml
+++ b/examples/memory/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 [dependencies]
 axum = "0.5.13"
 axum-login = { path = "../../" }
-async-trait = "0.1.58"
 
 [dependencies.rand]
 version = "0.8.5"

--- a/examples/memory/src/main.rs
+++ b/examples/memory/src/main.rs
@@ -6,14 +6,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use async_trait::async_trait;
-use axum::{
-    extract::{FromRequest, RequestParts},
-    http::StatusCode,
-    response::IntoResponse,
-    routing::get,
-    Extension, Router,
-};
+use axum::{response::IntoResponse, routing::get, Extension, Router};
 use axum_login::{
     axum_sessions::{async_session::MemoryStore as SessionMemoryStore, SessionLayer},
     memory_store::MemoryStore as AuthMemoryStore,

--- a/examples/simple-with-role/src/main.rs
+++ b/examples/simple-with-role/src/main.rs
@@ -22,7 +22,7 @@ use axum_login::{
 use rand::Rng;
 use tokio::sync::RwLock;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
 enum Role {
     User,
     Admin,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -30,7 +30,7 @@ pub struct AuthLayer<User, Store, Role = ()> {
 impl<User, Store, Role> AuthLayer<User, Store, Role>
 where
     User: AuthUser<Role>,
-    Role: PartialEq + Clone + Send + Sync + 'static,
+    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
     Store: UserStore<Role, User = User>,
 {
     /// Creates a layer which will attach the [`AuthContext`] and `User` to
@@ -50,7 +50,7 @@ where
 
 impl<User, Store, Inner, Role> Layer<Inner> for AuthLayer<User, Store, Role>
 where
-    Role: PartialEq + Clone + Send + Sync + 'static,
+    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
     User: AuthUser<Role>,
     Store: UserStore<Role>,
 {
@@ -74,7 +74,7 @@ impl<User, Store, Role, Inner, ReqBody, ResBody> Service<Request<ReqBody>>
     for Auth<User, Store, Inner, Role>
 where
     User: AuthUser<Role>,
-    Role: PartialEq + Clone + Send + Sync + 'static,
+    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
     Store: UserStore<Role, User = User>,
     Inner: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send + 'static,
     ResBody: Default + Send + 'static,
@@ -132,7 +132,7 @@ where
 /// See [`RequireAuthorizationLayer::login`] for more details.
 pub struct Login<User, ResBody, Role = ()>
 where
-    Role: PartialEq + Clone + Send + Sync + 'static,
+    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
 {
     role: Option<Role>,
     _user_type: PhantomData<User>,
@@ -141,7 +141,7 @@ where
 
 impl<User, ResBody, Role> Clone for Login<User, ResBody, Role>
 where
-    Role: PartialEq + Clone + Send + Sync + 'static,
+    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
 {
     fn clone(&self) -> Self {
         Self {
@@ -154,7 +154,7 @@ where
 
 impl<User, ReqBody, ResBody, Role> AuthorizeRequest<ReqBody> for Login<User, ResBody, Role>
 where
-    Role: PartialEq + Clone + Send + Sync + 'static,
+    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
     User: AuthUser<Role>,
     ResBody: HttpBody + Default,
 {
@@ -180,7 +180,7 @@ where
                 Ok(())
             }
             (Some(expected_role), Some(user), Some(actual_role))
-                if expected_role == actual_role =>
+                if expected_role <= actual_role =>
             {
                 let user = user.clone();
                 request.extensions_mut().insert(user);
@@ -205,7 +205,7 @@ pub struct RequireAuthorizationLayer<User, Role = ()>(User, Role);
 
 impl<User, Role> RequireAuthorizationLayer<User, Role>
 where
-    Role: PartialEq + Clone + Send + Sync + 'static,
+    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
     User: AuthUser<Role>,
 {
     /// Authorizes requests by requiring a logged in user, otherwise it rejects

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,5 +1,6 @@
 use std::{
     marker::PhantomData,
+    ops::{RangeBounds, RangeFull},
     task::{Context, Poll},
 };
 
@@ -11,6 +12,7 @@ use axum::{
     Extension,
 };
 use axum_sessions::SessionHandle;
+use dyn_clone::DynClone;
 use futures::future::BoxFuture;
 use ring::hmac::{Key, HMAC_SHA512};
 use tower::{Layer, Service};
@@ -30,7 +32,7 @@ pub struct AuthLayer<User, Store, Role = ()> {
 impl<User, Store, Role> AuthLayer<User, Store, Role>
 where
     User: AuthUser<Role>,
-    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
+    Role: PartialOrd + PartialOrd + PartialEq + Clone + Send + Sync + 'static,
     Store: UserStore<Role, User = User>,
 {
     /// Creates a layer which will attach the [`AuthContext`] and `User` to
@@ -50,7 +52,7 @@ where
 
 impl<User, Store, Inner, Role> Layer<Inner> for AuthLayer<User, Store, Role>
 where
-    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
+    Role: PartialOrd + PartialOrd + PartialEq + Clone + Send + Sync + 'static,
     User: AuthUser<Role>,
     Store: UserStore<Role>,
 {
@@ -127,25 +129,43 @@ where
     }
 }
 
+trait RoleBounds<Role>: DynClone + Send + Sync {
+    fn contains(&self, role: Option<Role>) -> bool;
+}
+
+impl<T, Role> RoleBounds<Role> for T
+where
+    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
+    T: RangeBounds<Role> + Clone + Send + Sync,
+{
+    fn contains(&self, role: Option<Role>) -> bool {
+        if let Some(role) = role {
+            RangeBounds::contains(self, &role)
+        } else {
+            role.is_none()
+        }
+    }
+}
+
 /// Type that performs login authorization.
 ///
 /// See [`RequireAuthorizationLayer::login`] for more details.
 pub struct Login<User, ResBody, Role = ()>
 where
-    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
+    Role: PartialOrd + PartialOrd + PartialEq + Clone + Send + Sync + 'static,
 {
-    role: Option<Role>,
+    role_bounds: Box<dyn RoleBounds<Role>>,
     _user_type: PhantomData<User>,
     _body_type: PhantomData<fn() -> ResBody>,
 }
 
 impl<User, ResBody, Role> Clone for Login<User, ResBody, Role>
 where
-    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
+    Role: PartialOrd + PartialOrd + PartialEq + Clone + Send + Sync + 'static,
 {
     fn clone(&self) -> Self {
         Self {
-            role: self.role.clone(),
+            role_bounds: dyn_clone::clone_box(&*self.role_bounds),
             _user_type: PhantomData,
             _body_type: PhantomData,
         }
@@ -154,7 +174,7 @@ where
 
 impl<User, ReqBody, ResBody, Role> AuthorizeRequest<ReqBody> for Login<User, ResBody, Role>
 where
-    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
+    Role: PartialOrd + PartialOrd + PartialEq + Clone + Send + Sync + 'static,
     User: AuthUser<Role>,
     ResBody: HttpBody + Default,
 {
@@ -169,24 +189,14 @@ where
             .get::<Option<User>>()
             .expect("Auth extension missing. Is the auth layer installed?");
 
-        let expected_role = self.role.clone();
-        let actual_role = user.as_ref().and_then(|user| user.get_role());
-
-        match (expected_role, user, actual_role) {
-            (None, Some(user), None | Some(_)) => {
+        match user {
+            Some(user) if self.role_bounds.contains(user.get_role()) => {
                 let user = user.clone();
                 request.extensions_mut().insert(user);
 
                 Ok(())
             }
-            (Some(expected_role), Some(user), Some(actual_role))
-                if expected_role <= actual_role =>
-            {
-                let user = user.clone();
-                request.extensions_mut().insert(user);
 
-                Ok(())
-            }
             _ => {
                 let unauthorized_response = Response::builder()
                     .status(http::StatusCode::UNAUTHORIZED)
@@ -216,7 +226,7 @@ where
         ResBody: HttpBody + Default,
     {
         tower_http::auth::RequireAuthorizationLayer::custom(Login::<_, _, _> {
-            role: None,
+            role_bounds: Box::new(..),
             _user_type: PhantomData,
             _body_type: PhantomData,
         })
@@ -226,13 +236,13 @@ where
     /// role, otherwise it rejects
     /// with [`http::StatusCode::UNAUTHORIZED`].
     pub fn login_with_role<ResBody>(
-        role: Role,
+        role_bounds: impl RangeBounds<Role> + Clone + Send + Sync + 'static,
     ) -> tower_http::auth::RequireAuthorizationLayer<Login<User, ResBody, Role>>
     where
         ResBody: HttpBody + Default,
     {
         tower_http::auth::RequireAuthorizationLayer::custom(Login::<_, _, _> {
-            role: Some(role),
+            role_bounds: Box::new(role_bounds),
             _user_type: PhantomData,
             _body_type: PhantomData,
         })

--- a/src/auth_user.rs
+++ b/src/auth_user.rs
@@ -17,7 +17,7 @@
 ///     password_hash: String,
 /// }
 ///
-/// #[derive(Debug, Clone, PartialEq)]
+/// #[derive(Debug, Clone, PartialEq, PartialOrd)]
 /// enum Role {
 ///     User,
 ///     Admin,
@@ -46,7 +46,7 @@
 /// ```
 pub trait AuthUser<Role = ()>: Clone + Send + Sync + 'static
 where
-    Role: PartialEq + Clone + Send + Sync + 'static,
+    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
 {
     /// Returns the ID of the user.
     ///

--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -48,7 +48,7 @@ impl<User, Store, Role> AuthContext<User, Store, Role>
 where
     User: AuthUser<Role>,
     Store: UserStore<Role, User = User>,
-    Role: PartialEq + Clone + Send + Sync + 'static,
+    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
 {
     fn get_session_auth_id(&self, password_hash: &str) -> String {
         let tag = hmac::sign(&self.key, password_hash.as_bytes());
@@ -126,7 +126,7 @@ where
 #[async_trait]
 impl<Body, User, Store, Role> FromRequest<Body> for AuthContext<User, Store, Role>
 where
-    Role: PartialEq + Clone + Send + Sync + 'static,
+    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
     Body: Send,
     User: AuthUser<Role>,
     Store: UserStore<Role, User = User>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@
 //!     role: Role,
 //! }
 //!
-//! #[derive(Debug, Clone, PartialEq)]
+//! #[derive(Debug, Clone, PartialEq, PartialOrd)]
 //! enum Role {
 //!     User,
 //!     Admin,

--- a/src/memory_store.rs
+++ b/src/memory_store.rs
@@ -35,7 +35,7 @@ impl<User> MemoryStore<User> {
 #[async_trait]
 impl<User, Role> UserStore<Role> for MemoryStore<User>
 where
-    Role: PartialEq + Clone + Send + Sync + 'static,
+    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
     User: AuthUser<Role>,
 {
     type User = User;

--- a/src/sqlx_store.rs
+++ b/src/sqlx_store.rs
@@ -45,7 +45,7 @@ macro_rules! impl_user_store {
         #[async_trait]
         impl<User, Role> UserStore<Role> for $store<User, Role>
         where
-            Role: PartialEq + Clone + Send + Sync + 'static,
+            Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
             User: AuthUser<Role> + Unpin + for<'r> FromRow<'r, $row>,
         {
             type User = User;

--- a/src/user_store.rs
+++ b/src/user_store.rs
@@ -7,7 +7,7 @@ use crate::{AuthUser, Result};
 #[async_trait]
 pub trait UserStore<Role>: Clone + Send + Sync + 'static
 where
-    Role: PartialEq + Clone + Send + Sync + 'static,
+    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
 {
     /// An associated user type which will be loaded from the store.
     type User: AuthUser<Role>;


### PR DESCRIPTION
This PR allows to define an ordering for roles. This makes it possible to create sub- and super roles.

Closes #18.