### PR TITLE
Create a `secrecy` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { version = "1.20.1", features = ["sync"] }
 tower = "0.4.13"
 tower-http = { version = "0.3.4", features = ["auth"] }
 tracing = "0.1.36"
+secrecy = "0.8.0"
 dyn-clone = "1.0.9"
 
 [dev-dependencies]

--- a/examples/login-with-role/src/main.rs
+++ b/examples/login-with-role/src/main.rs
@@ -10,6 +10,7 @@ use axum::{response::IntoResponse, routing::get, Extension, Router};
 use axum_login::{
     axum_sessions::{async_session::MemoryStore as SessionMemoryStore, SessionLayer},
     memory_store::MemoryStore as AuthMemoryStore,
+    secrecy::SecretVec,
     AuthLayer, AuthUser, RequireAuthorizationLayer,
 };
 use rand::Rng;
@@ -45,8 +46,8 @@ impl AuthUser<Role> for User {
         format!("{}", self.id)
     }
 
-    fn get_password_hash(&self) -> String {
-        self.password_hash.clone()
+    fn get_password_hash(&self) -> SecretVec<u8> {
+        SecretVec::new(self.password_hash.clone().into())
     }
 
     fn get_role(&self) -> Option<Role> {

--- a/examples/memory/src/main.rs
+++ b/examples/memory/src/main.rs
@@ -10,6 +10,7 @@ use axum::{response::IntoResponse, routing::get, Extension, Router};
 use axum_login::{
     axum_sessions::{async_session::MemoryStore as SessionMemoryStore, SessionLayer},
     memory_store::MemoryStore as AuthMemoryStore,
+    secrecy::SecretVec,
     AuthLayer, AuthUser, RequireAuthorizationLayer,
 };
 use rand::Rng;
@@ -37,8 +38,8 @@ impl AuthUser for User {
         format!("{}", self.id)
     }
 
-    fn get_password_hash(&self) -> String {
-        self.password_hash.clone()
+    fn get_password_hash(&self) -> SecretVec<u8> {
+        SecretVec::new(self.password_hash.clone().into())
     }
 }
 

--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -25,6 +25,7 @@ use axum_login::{
         extractors::{ReadableSession, WritableSession},
         SameSite, SessionLayer,
     },
+    secrecy::SecretVec,
     AuthLayer, AuthUser, RequireAuthorizationLayer, SqliteStore,
 };
 use oauth2::{
@@ -47,8 +48,8 @@ impl AuthUser for User {
         format!("{}", self.id)
     }
 
-    fn get_password_hash(&self) -> String {
-        self.password_hash.clone()
+    fn get_password_hash(&self) -> SecretVec<u8> {
+        SecretVec::new(self.password_hash.clone().into())
     }
 }
 

--- a/examples/simple-with-role/src/main.rs
+++ b/examples/simple-with-role/src/main.rs
@@ -17,6 +17,7 @@ use axum::{
 use axum_login::{
     axum_sessions::{async_session::MemoryStore as SessionMemoryStore, SessionLayer},
     memory_store::MemoryStore as AuthMemoryStore,
+    secrecy::SecretVec,
     AuthLayer, AuthUser, RequireAuthorizationLayer,
 };
 use rand::Rng;
@@ -53,8 +54,8 @@ impl AuthUser<Role> for User {
         format!("{}", self.id)
     }
 
-    fn get_password_hash(&self) -> String {
-        self.password_hash.clone()
+    fn get_password_hash(&self) -> SecretVec<u8> {
+        SecretVec::new(self.password_hash.clone().into())
     }
 
     fn get_role(&self) -> Option<Role> {

--- a/examples/sqlite/src/main.rs
+++ b/examples/sqlite/src/main.rs
@@ -7,6 +7,7 @@
 use axum::{response::IntoResponse, routing::get, Extension, Router};
 use axum_login::{
     axum_sessions::{async_session::MemoryStore, SessionLayer},
+    secrecy::SecretVec,
     AuthLayer, AuthUser, RequireAuthorizationLayer, SqliteStore,
 };
 use rand::Rng;
@@ -24,8 +25,8 @@ impl AuthUser for User {
         format!("{}", self.id)
     }
 
-    fn get_password_hash(&self) -> String {
-        self.password_hash.clone()
+    fn get_password_hash(&self) -> SecretVec<u8> {
+        SecretVec::new(self.password_hash.clone().into())
     }
 }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -288,8 +288,8 @@ mod tests {
             format!("{}", self.id)
         }
 
-        fn get_password_hash(&self) -> String {
-            self.password_hash.clone()
+        fn get_password_hash(&self) -> secrecy::SecretVec<u8> {
+            secrecy::SecretVec::new(self.password_hash.clone().into())
         }
     }
 

--- a/src/auth_user.rs
+++ b/src/auth_user.rs
@@ -9,6 +9,7 @@
 ///
 /// ```rust
 /// use axum_login::AuthUser;
+/// use secrecy::{ExposeSecret, SecretVec};
 ///
 /// #[derive(Debug, Clone)]
 /// struct MyUser {
@@ -28,8 +29,8 @@
 ///         format!("{}", self.id)
 ///     }
 ///
-///     fn get_password_hash(&self) -> String {
-///         self.password_hash.clone()
+///     fn get_password_hash(&self) -> SecretVec<u8> {
+///         SecretVec::new(self.password_hash.clone().into())
 ///     }
 /// }
 ///
@@ -41,7 +42,10 @@
 /// };
 ///
 /// assert_eq!(user.get_id(), "1".to_string());
-/// assert_eq!(user.get_password_hash(), "hunter42".to_string());
+/// assert_eq!(
+///     user.get_password_hash().expose_secret(),
+///     SecretVec::new("hunter42".into()).expose_secret()
+/// );
 /// # }
 /// ```
 pub trait AuthUser<Role = ()>: Clone + Send + Sync + 'static
@@ -58,7 +62,7 @@ where
     ///
     /// This is used to generate a unique auth ID for the session. Note that a
     /// password hash changing will cause the session to become invalidated.
-    fn get_password_hash(&self) -> String;
+    fn get_password_hash(&self) -> secrecy::SecretVec<u8>;
 
     /// Returns the role assigned to the given user.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@
 //!     axum_sessions::{async_session::MemoryStore as SessionMemoryStore, SessionLayer},
 //!     extractors::AuthContext,
 //!     memory_store::MemoryStore as AuthMemoryStore,
+//!     secrecy::SecretVec,
 //!     AuthLayer, AuthUser, RequireAuthorizationLayer,
 //! };
 //! use rand::Rng;
@@ -95,8 +96,8 @@
 //!         format!("{}", self.id)
 //!     }
 //!
-//!     fn get_password_hash(&self) -> String {
-//!         self.password_hash.clone()
+//!     fn get_password_hash(&self) -> SecretVec<u8> {
+//!         SecretVec::new(self.password_hash.clone().into())
 //!     }
 //!
 //!     fn get_role(&self) -> Option<Role> {
@@ -172,6 +173,7 @@ pub use auth::{AuthLayer, RequireAuthorizationLayer};
 pub use auth_user::AuthUser;
 pub use axum_sessions;
 use eyre::Error;
+pub use secrecy;
 #[cfg(feature = "mssql")]
 pub use sqlx_store::MssqlStore;
 #[cfg(feature = "mysql")]


### PR DESCRIPTION
This feature requires the `AuthUser` to return a securely-handled version of the `password_hash`.

Closes #7.