### PR TITLE
allow a little bit more flexibility with UserStore::load_user

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,7 +81,7 @@ jobs:
           command: test
           args: --all --all-features --all-targets
       - name: Coverage
-        run: cargo tarpaulin -o Lcov --output-dir ./coverage
+        run: cargo tarpaulin --all --all-features --all-targets -o Lcov --output-dir ./coverage
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 **/target
 **/Cargo.lock
 **/.env
+.idea/
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# 0.5.0
+**BREAKING CHANGES**: 
+- `SqlxStore`: remove support for `table_name` field in the struct in favor of the whole user-loading `query` override mechanism.
+
+**OTHER CHANGES**:
+- Add this changelog :tada:
+- extend .gitignore
+
+# 0.4.1
+- expose sqlx_store::SqlxStore [PR #31](https://github.com/maxcountryman/axum-login/pull/31)
+- update README example
+# 0.4.0
+- Bump Axum to 0.6.0
+- Introduce a `secrecy` feature
+# 0.3.0
+- Implement role bounds
+- Implement `PartialOrd` for `Role`
+- Implement a role-based `RequireAuthorizationLayer`
+- Implement basic RBAC support
+- Add an example to require a special user field value
+- Remove std::fmt::Debug from AuthUser requirements
+- Add session csrf_state and logging
+- Add oauth example
+# 0.2.0
+- General fixes and improvements
+# 0.1.0
+- Initial release :tada:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+lint:
+	cargo clippy --all --all-targets --all-features -- -Dwarnings
+	cargo fmt --all -- --check
+
+test:
+	cargo tarpaulin --all --all-features --all-targets -o Lcov --output-dir ./coverage
+
+.PHONY: lint test

--- a/src/sqlx_store.rs
+++ b/src/sqlx_store.rs
@@ -1,7 +1,7 @@
 use std::marker::{PhantomData, Unpin};
 
 use async_trait::async_trait;
-use sqlx::FromRow;
+use sqlx::{database::Database, encode::Encode, FromRow};
 #[cfg(feature = "mssql")]
 use sqlx::{mssql::MssqlRow, MssqlPool};
 #[cfg(feature = "mysql")]
@@ -13,9 +13,6 @@ use sqlx::{sqlite::SqliteRow, SqlitePool};
 
 use crate::{user_store::UserStore, AuthUser};
 
-const TABLE_NAME_TEMPLATE: &str = "{{table_name}}";
-const COLUMN_NAME_TEMPLATE: &str = "{{column_name}}";
-
 /// A generic SQLx user store.
 ///
 /// Concrete implementations are provided as well and should usually be used
@@ -23,9 +20,7 @@ const COLUMN_NAME_TEMPLATE: &str = "{{column_name}}";
 #[derive(Clone, Debug)]
 pub struct SqlxStore<Pool, User, Role = ()> {
     pool: Pool,
-    table_name: String,
-    column_name: String,
-    query: Option<String>,
+    query: String,
     _user_type: PhantomData<User>,
     _role_type: PhantomData<Role>,
 }
@@ -35,52 +30,18 @@ impl<Pool, User, Role> SqlxStore<Pool, User, Role> {
     pub fn new(pool: Pool) -> Self {
         Self {
             pool,
-            table_name: "users".into(),
-            column_name: "id".into(),
-            query: None,
+            query: "SELECT * FROM users WHERE id = $1".to_string(),
             _user_type: Default::default(),
             _role_type: Default::default(),
         }
     }
 
-    /// Sets the name of the table which will be queried when calling
+    /// Sets the query that will be used to query the users table with
     /// `load_user`.
-    pub fn with_table_name(mut self, table_name: impl AsRef<str>) -> Self {
-        let table_name = table_name.as_ref();
-        self.table_name = table_name.to_string();
-        self
-    }
-
-    /// Sets the name of the column that will be used to query the user with
-    /// `load_user`.
-    pub fn with_column_name(mut self, column_name: impl AsRef<str>) -> Self {
-        let column_name = column_name.as_ref();
-        self.column_name = column_name.to_string();
-        self
-    }
-
-    /// Sets the query that will be used to query the user with `load_user`.
-    /// Note: It doesn't really make sense to use `with_query`
-    /// and `with_table_name` / `with_column_name` pair at the same time.
-    /// The query, if set, will be used instead of the table name and column name.
     pub fn with_query(mut self, query: impl AsRef<str>) -> Self {
         let query = query.as_ref();
-        self.query = Some(query.to_string());
+        self.query = query.to_string();
         self
-    }
-
-    async fn build_db_query(&self) -> String {
-        if let Some(query) = self.query.clone() {
-            query
-        } else {
-            let mut query = format!(
-                "SELECT * FROM {} WHERE {} = $1",
-                TABLE_NAME_TEMPLATE, COLUMN_NAME_TEMPLATE
-            );
-            query = query.replace(TABLE_NAME_TEMPLATE, &self.table_name);
-            query = query.replace(COLUMN_NAME_TEMPLATE, &self.column_name);
-            query
-        }
     }
 }
 
@@ -95,10 +56,9 @@ macro_rules! impl_user_store {
             type User = User;
 
             async fn load_user(&self, user_id: &str) -> crate::Result<Option<Self::User>> {
-                let query = self.build_db_query().await;
                 let mut connection = self.pool.acquire().await?;
 
-                let user: Option<User> = sqlx::query_as(&query)
+                let user: Option<User> = sqlx::query_as(&self.query)
                     .bind(&user_id)
                     .fetch_optional(&mut connection)
                     .await?;
@@ -133,13 +93,13 @@ impl_user_store!(PostgresStore, PgRow);
 #[cfg(feature = "sqlite")]
 impl_user_store!(SqliteStore, SqliteRow);
 
-
 #[cfg(test)]
 mod tests {
     //todo: integration tests - docker-compose for non-memory db servers?
 
     use secrecy::SecretVec;
     use sqlx::SqlitePool;
+
     use crate::{AuthUser, SqliteStore, SqlxStore};
 
     #[derive(Debug, Default, Clone, sqlx::FromRow)]
@@ -158,47 +118,15 @@ mod tests {
         }
     }
 
-
     #[sqlx::test]
-    async fn test_store_table_override(pool: SqlitePool) {
-        let store = SqliteStore::<User>::new(pool).with_table_name("foo");
-        assert_eq!(store.table_name, "foo");
-    }
-
-    #[sqlx::test]
-    async fn test_store_column_override(pool: SqlitePool) {
-        let store = SqliteStore::<User>::new(pool).with_column_name("foo");
-        assert_eq!(store.column_name, "foo");
-    }
-
-    #[sqlx::test]
-    async fn test_store_without_query_override_has_query_none(pool: SqlitePool) {
+    async fn test_store_without_query_override_has_default_query(pool: SqlitePool) {
         let store = SqliteStore::<User>::new(pool);
-        assert_eq!(store.query, None);
+        assert_eq!(store.query, "SELECT * FROM users WHERE id = $1".to_string());
     }
 
     #[sqlx::test]
     async fn test_store_full_query_override(pool: SqlitePool) {
         let store = SqliteStore::<User>::new(pool).with_query("select 1 from foo");
-        assert_eq!(store.query, Some("select 1 from foo".to_string()));
-    }
-
-    #[sqlx::test]
-    async fn test_store_query_builder_respects_explicit_query(pool: SqlitePool) {
-        let expected_q = "SELECT 'something' FROM certainly_changed_table WHERE certainly_changed_column = $1";
-        let store = SqliteStore::<User>::new(pool).with_query(expected_q);
-        assert_eq!(store.build_db_query().await, expected_q);
-    }
-
-    #[sqlx::test]
-    async fn test_store_query_builder_respects_explicit_table_and_column_name(pool: SqlitePool) {
-        let expected_q = "SELECT * FROM certainly_changed_table WHERE certainly_changed_column = $1";
-        let table = "certainly_changed_table";
-        let column = "certainly_changed_column";
-
-        let store = SqliteStore::<User>::new(pool)
-            .with_table_name(table)
-            .with_column_name(column);
-        assert_eq!(store.build_db_query().await, expected_q);
+        assert_eq!(store.query, "select 1 from foo".to_string());
     }
 }

--- a/src/sqlx_store.rs
+++ b/src/sqlx_store.rs
@@ -1,7 +1,7 @@
 use std::marker::{PhantomData, Unpin};
 
 use async_trait::async_trait;
-use sqlx::{database::Database, encode::Encode, FromRow};
+use sqlx::FromRow;
 #[cfg(feature = "mssql")]
 use sqlx::{mssql::MssqlRow, MssqlPool};
 #[cfg(feature = "mysql")]

--- a/src/sqlx_store.rs
+++ b/src/sqlx_store.rs
@@ -100,7 +100,7 @@ mod tests {
     use secrecy::SecretVec;
     use sqlx::SqlitePool;
 
-    use crate::{AuthUser, SqliteStore, SqlxStore};
+    use crate::{AuthUser, SqliteStore};
 
     #[derive(Debug, Default, Clone, sqlx::FromRow)]
     struct User {


### PR DESCRIPTION
Hi.
A couple of additions to UserStore and UserStore::load_user:
- the column name can be set the same way the table name can
- the query might be overridden altogether (overrides column name and table name settings)
- testing the change using Sqlite store -- this is not great, but that was easier than stubbing a NullPool, NullStore, NullDatabase etc. all the way down just to have a plain unit test. If there's a better way, I am all ears.

Additionally, a food for thought:
I could take a stab at setting up integration tests scaffolding using docker images for the database servers supported by axum-login.