### PR TITLE
Parametrize type of user ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 # 0.5.0
-**BREAKING CHANGES**: 
-- `SqlxStore`: remove support for `table_name` field in the struct in favor of the whole user-loading `query` override mechanism.
+**BREAKING CHANGES**:
+- Parametrize the `UserId` type (formerly hard-coded to `String`) in `AuthUser`, `AuthContext`, and `RequireAuthorizationLayer`.
+- `SqlxStore`: Remove `with_table_name` and `with_column_name` in favor of `with_query`.
 
 **OTHER CHANGES**:
 - Add this changelog :tada:
-- extend .gitignore
+- Extend .gitignore
 
 # 0.4.1
-- expose sqlx_store::SqlxStore [PR #31](https://github.com/maxcountryman/axum-login/pull/31)
-- update README example
+- Expose `sqlx_store::SqlxStore` [PR #31](https://github.com/maxcountryman/axum-login/pull/31)
+- Update README example
 # 0.4.0
 - Bump Axum to 0.6.0
 - Introduce a `secrecy` feature
@@ -18,9 +19,8 @@
 - Implement a role-based `RequireAuthorizationLayer`
 - Implement basic RBAC support
 - Add an example to require a special user field value
-- Remove std::fmt::Debug from AuthUser requirements
-- Add session csrf_state and logging
-- Add oauth example
+- Remove `std::fmt::Debug` from `AuthUser` requirements
+- Add `oauth` example
 # 0.2.0
 - General fixes and improvements
 # 0.1.0

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ struct User {
     name: String,
 }
 
-impl AuthUser for User {
-    fn get_id(&self) -> String {
-        format!("{}", self.id)
+impl AuthUser<i64> for User {
+    fn get_id(&self) -> i64 {
+        self.id
     }
 
     fn get_password_hash(&self) -> SecretVec<u8> {
@@ -76,7 +76,7 @@ impl AuthUser for User {
     }
 }
 
-type AuthContext = axum_login::extractors::AuthContext<User, SqliteStore<User>>;
+type AuthContext = axum_login::extractors::AuthContext<i64, User, SqliteStore<User>>;
 
 #[tokio::main]
 async fn main() {
@@ -117,7 +117,7 @@ async fn main() {
 
     let app = Router::new()
         .route("/protected", get(protected_handler))
-        .route_layer(RequireAuthorizationLayer::<User>::login())
+        .route_layer(RequireAuthorizationLayer::<i64, User>::login())
         .route("/login", get(login_handler))
         .route("/logout", get(logout_handler))
         .layer(auth_layer)

--- a/axum-login-tests/tests/sqlx_store_tests.rs
+++ b/axum-login-tests/tests/sqlx_store_tests.rs
@@ -6,9 +6,9 @@ struct User {
     password_hash: String,
 }
 
-impl AuthUser for User {
-    fn get_id(&self) -> String {
-        format!("{}", self.id)
+impl AuthUser<i32> for User {
+    fn get_id(&self) -> i32 {
+        self.id
     }
 
     fn get_password_hash(&self) -> SecretVec<u8> {
@@ -25,12 +25,10 @@ mod tests_pg {
 
     #[sqlx::test(fixtures("users"))]
     async fn test_load_user(pool: PgPool) {
-        // custom query because the default one assumes text-ish id column
-        let store = PostgresStore::<User>::new(pool)
-            .with_query("SELECT * FROM users WHERE id = $1::numeric");
-        let user = store.load_user("1").await.unwrap().unwrap();
+        let store = PostgresStore::<User>::new(pool);
 
-        assert_eq!(user.get_id(), "1");
+        let user = store.load_user(&1).await.unwrap().unwrap();
+        assert_eq!(user.get_id(), 1);
     }
 }
 
@@ -46,9 +44,8 @@ mod tests_mysql {
         // custom query because of the way mysql binds are done
         let store = MySqlStore::<User>::new(pool).with_query("SELECT * FROM users WHERE id = ?");
 
-        let user = store.load_user("1").await.unwrap().unwrap();
-
-        assert_eq!(user.get_id(), "1");
+        let user = store.load_user(&1).await.unwrap().unwrap();
+        assert_eq!(user.get_id(), 1);
     }
 }
 
@@ -63,8 +60,7 @@ mod tests_sqlite {
     async fn test_load_user(pool: SqlitePool) {
         let store = SqliteStore::<User>::new(pool);
 
-        let user = store.load_user("1").await.unwrap().unwrap();
-
-        assert_eq!(user.get_id(), "1");
+        let user = store.load_user(&1).await.unwrap().unwrap();
+        assert_eq!(user.get_id(), 1);
     }
 }

--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -35,6 +35,7 @@ base64 = "0.13.0"
 eyre = "0.6.8"
 futures = "0.3.21"
 ring = "0.16.20"
+serde = "1.0.152"
 serde_json = "1.0.83"
 sqlx = { version = "0.6.1", optional = true }
 tokio = { version = "1.20.1", features = ["sync"] }

--- a/axum-login/src/auth_user.rs
+++ b/axum-login/src/auth_user.rs
@@ -24,9 +24,9 @@
 ///     Admin,
 /// }
 ///
-/// impl AuthUser<Role> for MyUser {
-///     fn get_id(&self) -> String {
-///         format!("{}", self.id)
+/// impl AuthUser<i64, Role> for MyUser {
+///     fn get_id(&self) -> i64 {
+///         self.id
 ///     }
 ///
 ///     fn get_password_hash(&self) -> SecretVec<u8> {
@@ -41,14 +41,14 @@
 ///     password_hash: "hunter42".to_string(),
 /// };
 ///
-/// assert_eq!(user.get_id(), "1".to_string());
+/// assert_eq!(user.get_id(), 1);
 /// assert_eq!(
 ///     user.get_password_hash().expose_secret(),
 ///     SecretVec::new("hunter42".into()).expose_secret()
 /// );
 /// # }
 /// ```
-pub trait AuthUser<Role = ()>: Clone + Send + Sync + 'static
+pub trait AuthUser<Id, Role = ()>: Clone + Send + Sync + 'static
 where
     Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
 {
@@ -56,7 +56,7 @@ where
     ///
     /// This is used to generate the user ID for the session. We assume this
     /// value is globally unique and will not change.
-    fn get_id(&self) -> String;
+    fn get_id(&self) -> Id;
 
     /// Returns the password hash of the user.
     ///

--- a/axum-login/src/lib.rs
+++ b/axum-login/src/lib.rs
@@ -22,10 +22,10 @@
 //!
 //! In order for your user type to interoperate with this crate, you'll need to
 //! implement `AuthUser` for it. Generally this should be straightforward. The
-//! crate assumes you can provide a stable identifier as well as password hash,
-//! both in terms of `String`. In the case of the latter, the semantics of
-//! re-authentication can be controlled: if this value changes, then the session
-//! becomes invalidate and the user must re-authenticate.
+//! crate assumes you can provide a stable identifier of generic type `UserId`,
+//! as well as a password hash of type `String`. In the case of the latter, the
+//! semantics of re-authentication can be controlled: if this value changes,
+//! then the session becomes invalidated and the user must re-authenticate.
 //!
 //! ## Roles
 //!
@@ -91,9 +91,9 @@
 //!     }
 //! }
 //!
-//! impl AuthUser<Role> for User {
-//!     fn get_id(&self) -> String {
-//!         format!("{}", self.id)
+//! impl AuthUser<usize, Role> for User {
+//!     fn get_id(&self) -> usize {
+//!         self.id
 //!     }
 //!
 //!     fn get_password_hash(&self) -> SecretVec<u8> {
@@ -105,7 +105,8 @@
 //!     }
 //! }
 //!
-//! type Auth = AuthContext<User, AuthMemoryStore<User>, Role>;
+//! type Auth = AuthContext<usize, User, AuthMemoryStore<usize, User>, Role>;
+//! type RequireAuth = RequireAuthorizationLayer<usize, User, Role>;
 //!
 //! #[tokio::main]
 //! async fn main() {
@@ -141,11 +142,9 @@
 //!
 //!     let app = Router::new()
 //!         .route("/admin", get(admin_handler))
-//!         .route_layer(RequireAuthorizationLayer::<User, Role>::login_with_role(
-//!             Role::Admin..,
-//!         ))
+//!         .route_layer(RequireAuth::login_with_role(Role::Admin..))
 //!         .route("/", get(protected_handler))
-//!         .route_layer(RequireAuthorizationLayer::<User, Role>::login())
+//!         .route_layer(RequireAuth::login())
 //!         .route("/login", get(login_handler))
 //!         .route("/logout", get(logout_handler))
 //!         .layer(auth_layer)

--- a/axum-login/src/user_store.rs
+++ b/axum-login/src/user_store.rs
@@ -5,12 +5,12 @@ use crate::{AuthUser, Result};
 /// A trait which defines a method that allows retrieval of users from an
 /// arbitrary backend.
 #[async_trait]
-pub trait UserStore<Role>: Clone + Send + Sync + 'static
+pub trait UserStore<UserId, Role>: Clone + Send + Sync + 'static
 where
     Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
 {
     /// An associated user type which will be loaded from the store.
-    type User: AuthUser<Role>;
+    type User: AuthUser<UserId, Role>;
 
     /// Load and return a user.
     ///
@@ -19,5 +19,5 @@ where
     /// unique, stable identifier of the user is available. See [`AuthUser`]
     /// for expected minimal interface of the user type itself.
     #[must_use]
-    async fn load_user(&self, user_id: &str) -> Result<Option<Self::User>>;
+    async fn load_user(&self, user_id: &UserId) -> Result<Option<Self::User>>;
 }

--- a/examples/login-with-role/src/main.rs
+++ b/examples/login-with-role/src/main.rs
@@ -41,9 +41,9 @@ impl User {
     }
 }
 
-impl AuthUser<Role> for User {
-    fn get_id(&self) -> String {
-        format!("{}", self.id)
+impl AuthUser<usize, Role> for User {
+    fn get_id(&self) -> usize {
+        self.id
     }
 
     fn get_password_hash(&self) -> SecretVec<u8> {
@@ -55,9 +55,10 @@ impl AuthUser<Role> for User {
     }
 }
 
-type AuthContext = axum_login::extractors::AuthContext<User, AuthMemoryStore<User>, Role>;
+type AuthContext =
+    axum_login::extractors::AuthContext<usize, User, AuthMemoryStore<usize, User>, Role>;
 
-type RequireAuth = RequireAuthorizationLayer<User, Role>;
+type RequireAuth = RequireAuthorizationLayer<usize, User, Role>;
 
 #[tokio::main]
 async fn main() {

--- a/examples/memory/src/main.rs
+++ b/examples/memory/src/main.rs
@@ -33,9 +33,9 @@ impl User {
     }
 }
 
-impl AuthUser for User {
-    fn get_id(&self) -> String {
-        format!("{}", self.id)
+impl AuthUser<usize> for User {
+    fn get_id(&self) -> usize {
+        self.id
     }
 
     fn get_password_hash(&self) -> SecretVec<u8> {
@@ -43,7 +43,7 @@ impl AuthUser for User {
     }
 }
 
-type AuthContext = axum_login::extractors::AuthContext<User, AuthMemoryStore<User>>;
+type AuthContext = axum_login::extractors::AuthContext<usize, User, AuthMemoryStore<usize, User>>;
 
 #[tokio::main]
 async fn main() {
@@ -75,7 +75,7 @@ async fn main() {
 
     let app = Router::new()
         .route("/protected", get(protected_handler))
-        .route_layer(RequireAuthorizationLayer::<User>::login())
+        .route_layer(RequireAuthorizationLayer::<usize, User>::login())
         .route("/login", get(login_handler))
         .route("/logout", get(logout_handler))
         .layer(auth_layer)

--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -43,9 +43,9 @@ struct User {
     name: String,
 }
 
-impl AuthUser for User {
-    fn get_id(&self) -> String {
-        format!("{}", self.id)
+impl AuthUser<i64> for User {
+    fn get_id(&self) -> i64 {
+        self.id
     }
 
     fn get_password_hash(&self) -> SecretVec<u8> {
@@ -53,7 +53,7 @@ impl AuthUser for User {
     }
 }
 
-type AuthContext = axum_login::extractors::AuthContext<User, SqliteStore<User>>;
+type AuthContext = axum_login::extractors::AuthContext<i64, User, SqliteStore<User>>;
 
 #[tokio::main]
 async fn main() {
@@ -76,7 +76,7 @@ async fn main() {
 
     let app = Router::new()
         .route("/protected", get(protected_handler))
-        .route_layer(RequireAuthorizationLayer::<User>::login())
+        .route_layer(RequireAuthorizationLayer::<i64, User>::login())
         .route("/login", get(login_handler))
         .route("/auth/google/callback", get(oauth_callback_handler))
         .route("/logout", get(logout_handler))

--- a/examples/simple-with-role/src/main.rs
+++ b/examples/simple-with-role/src/main.rs
@@ -49,9 +49,9 @@ impl User {
     }
 }
 
-impl AuthUser<Role> for User {
-    fn get_id(&self) -> String {
-        format!("{}", self.id)
+impl AuthUser<usize, Role> for User {
+    fn get_id(&self) -> usize {
+        self.id
     }
 
     fn get_password_hash(&self) -> SecretVec<u8> {
@@ -114,7 +114,8 @@ where
     }
 }
 
-type AuthContext = axum_login::extractors::AuthContext<User, AuthMemoryStore<User>, Role>;
+type AuthContext =
+    axum_login::extractors::AuthContext<usize, User, AuthMemoryStore<usize, User>, Role>;
 
 #[tokio::main]
 async fn main() {
@@ -156,7 +157,7 @@ async fn main() {
         .route("/protected", get(protected_handler))
         .route("/protected_admin", get(admin_handler))
         .route("/protected_user", get(user_handler))
-        .route_layer(RequireAuthorizationLayer::<User, Role>::login())
+        .route_layer(RequireAuthorizationLayer::<usize, User, Role>::login())
         .route("/login", get(login_handler))
         .route("/logout", get(logout_handler))
         .layer(auth_layer)

--- a/examples/sqlite/src/main.rs
+++ b/examples/sqlite/src/main.rs
@@ -20,9 +20,9 @@ struct User {
     name: String,
 }
 
-impl AuthUser for User {
-    fn get_id(&self) -> String {
-        format!("{}", self.id)
+impl AuthUser<i64> for User {
+    fn get_id(&self) -> i64 {
+        self.id
     }
 
     fn get_password_hash(&self) -> SecretVec<u8> {
@@ -30,7 +30,7 @@ impl AuthUser for User {
     }
 }
 
-type AuthContext = axum_login::extractors::AuthContext<User, SqliteStore<User>>;
+type AuthContext = axum_login::extractors::AuthContext<i64, User, SqliteStore<User>>;
 
 #[tokio::main]
 async fn main() {
@@ -71,7 +71,7 @@ async fn main() {
 
     let app = Router::new()
         .route("/protected", get(protected_handler))
-        .route_layer(RequireAuthorizationLayer::<User>::login())
+        .route_layer(RequireAuthorizationLayer::<i64, User>::login())
         .route("/login", get(login_handler))
         .route("/logout", get(logout_handler))
         .layer(auth_layer)


### PR DESCRIPTION
Require specifying the `UserId` type, which avoids conversion of numeric IDs to `String` by the `get_id` method of the `AuthUser` trait, and type casting of the corresponding placeholder in the (necessarily custom) SQL query.

(@czotomo [commented](https://github.com/maxcountryman/axum-login/pull/38#discussion_r1046313226) about this.)