### PR TITLE
Add optional redirect in RequireAuthorizationLayer

### DIFF
--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -31,6 +31,7 @@ sqlx = ["sqlx/runtime-tokio-rustls"]
 async-trait = "0.1.57"
 axum = "0.6"
 axum-sessions = "0.5"
+percent-encoding = "2.2"
 base64 = "0.13.0"
 eyre = "0.6.8"
 futures = "0.3.21"

--- a/axum-login/src/lib.rs
+++ b/axum-login/src/lib.rs
@@ -136,6 +136,10 @@
 //!         format!("Logged in as: {}", user.name)
 //!     }
 //!
+//!     async fn account_handler(Extension(user): Extension<User>) -> impl IntoResponse {
+//!         format!("Logged in as: {}", user.name)
+//!     }
+//!
 //!     async fn admin_handler(Extension(user): Extension<User>) -> impl IntoResponse {
 //!         format!("Logged in as admin: {}", user.name)
 //!     }
@@ -145,6 +149,14 @@
 //!         .route_layer(RequireAuth::login_with_role(Role::Admin..))
 //!         .route("/", get(protected_handler))
 //!         .route_layer(RequireAuth::login())
+//!         .route(
+//!             "/account",
+//!             get(account_handler).layer(RequireAuth::login_with_role_or_redirect(
+//!                 Role::Admin..,
+//!                 Arc::new("/login".into()),
+//!                 Some(Arc::new("next".into())),
+//!             )),
+//!         )
 //!         .route("/login", get(login_handler))
 //!         .route("/logout", get(logout_handler))
 //!         .layer(auth_layer)


### PR DESCRIPTION
Allow redirection to a pre-defined url (for example, the login page) on authentication failure. This makes sense for some use-cases.

Additionally, you can optionally provide `redirect_field_name` which will add the original path the user requested as a URL query parameter, allowing the crate's developer users to be able to redirect the user back to the protected page they had requested.

Example flow:

1. Unauthenticated visitor requests /protected
2. Visitor gets redirected to /login?next=/protected
3. Visitor logs in successfully, and the login page's POST handler redirects them to /protected

Inspired by the similar feature in Django:

https://docs.djangoproject.com/en/4.2/topics/auth/default/#the-login-required-decorator