### PR TITLE
Implement the rusqlite store

### DIFF
--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -26,6 +26,7 @@ mysql = ["sqlx/mysql"]
 postgres = ["sqlx/postgres"]
 sqlite = ["sqlx/sqlite"]
 sqlx = ["sqlx/runtime-tokio-rustls"]
+rusqlite = ["dep:rusqlite", "dep:tokio-rusqlite"]
 
 [dependencies]
 async-trait = "0.1.57"
@@ -41,6 +42,8 @@ sqlx = { version = "0.6", optional = true }
 tokio = { version = "1.20", features = ["sync"] }
 tower = "0.4"
 tower-http = { version = "0.4", features = ["auth"] }
+rusqlite = { version = "0.27.0", optional = true }
+tokio-rusqlite = { version = "0.2.0", optional = true }
 tracing = "0.1"
 secrecy = "0.8"
 dyn-clone = "1"

--- a/axum-login/src/lib.rs
+++ b/axum-login/src/lib.rs
@@ -177,12 +177,17 @@ mod auth_user;
 pub mod extractors;
 pub mod memory_store;
 
+#[cfg(feature = "rusqlite")]
+mod rusqlite_store;
+
 #[cfg(feature = "sqlx")]
 mod sqlx_store;
 mod user_store;
 pub use auth::{AuthLayer, RequireAuthorizationLayer};
 pub use auth_user::AuthUser;
 pub use axum_sessions;
+#[cfg(feature = "rusqlite")]
+pub use rusqlite_store::RusqliteStore;
 pub use secrecy;
 #[cfg(feature = "mssql")]
 pub use sqlx_store::MssqlStore;

--- a/axum-login/src/rusqlite_store.rs
+++ b/axum-login/src/rusqlite_store.rs
@@ -1,0 +1,162 @@
+use std::marker::{PhantomData, Unpin};
+
+use async_trait::async_trait;
+use rusqlite::{named_params, OptionalExtension, Row, ToSql};
+use tokio_rusqlite::Connection;
+
+use crate::{user_store::UserStore, AuthUser};
+
+/// A mapper from a rusqlite row to a concrete user-defined `User` struct.
+pub trait RusqliteUserMapper: Clone + Send + Sync + 'static {
+    type User;
+
+    fn map(row: &Row<'_>) -> Result<Self::User, rusqlite::Error>;
+}
+
+/// A store to support rusqlite as the underlying database crate.
+#[derive(Clone, Debug)]
+pub struct RusqliteStore<User, UserMapper: RusqliteUserMapper<User = User>, Role = ()> {
+    connection: Connection,
+    query: String,
+    _user_mapper: PhantomData<UserMapper>,
+    _user_type: PhantomData<User>,
+    _role_type: PhantomData<Role>,
+}
+
+impl<User, UserMapper, Role> RusqliteStore<User, UserMapper, Role>
+where
+    UserMapper: RusqliteUserMapper<User = User>,
+{
+    /// Creates a new store with the provided connection.
+    pub fn new(connection: Connection) -> Self {
+        Self {
+            connection,
+            query: "SELECT * FROM users WHERE id = :id".to_string(),
+            _user_mapper: Default::default(),
+            _user_type: Default::default(),
+            _role_type: Default::default(),
+        }
+    }
+
+    /// Sets the query that will be used to query the users table with
+    /// `load_user`.
+    pub fn with_query(mut self, query: impl AsRef<str>) -> Self {
+        let query = query.as_ref();
+        self.query = query.to_string();
+        self
+    }
+}
+
+#[async_trait]
+impl<UserId, User, UserMapper, Role> UserStore<UserId, Role>
+    for RusqliteStore<User, UserMapper, Role>
+where
+    UserId: Send + Sync + ToSql + Clone + 'static,
+    Role: PartialOrd + PartialEq + Clone + Send + Sync + 'static,
+    User: AuthUser<UserId, Role> + Unpin,
+    UserMapper: RusqliteUserMapper<User = User>,
+{
+    type User = User;
+    type Error = rusqlite::Error;
+
+    async fn load_user(&self, user_id: &UserId) -> Result<Option<Self::User>, Self::Error> {
+        let id = user_id.clone();
+        let query = self.query.clone();
+        self.connection
+            .call(move |conn| {
+                conn.query_row(&query, named_params! { ":id": id }, |row: &Row| {
+                    let user: Result<Self::User, rusqlite::Error> = UserMapper::map(row);
+                    user
+                })
+                .optional()
+            })
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use secrecy::SecretVec;
+    use tokio_rusqlite::Connection;
+
+    use super::RusqliteUserMapper;
+    use crate::{user_store::UserStore, AuthUser, RusqliteStore};
+
+    #[derive(Debug, Default, Clone, PartialEq, Eq)]
+    struct User {
+        id: i64,
+        password_hash: String,
+    }
+
+    impl AuthUser<i64> for User {
+        fn get_id(&self) -> i64 {
+            self.id
+        }
+
+        fn get_password_hash(&self) -> SecretVec<u8> {
+            SecretVec::new(self.password_hash.clone().into())
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct MyUserMapper;
+
+    impl RusqliteUserMapper for MyUserMapper {
+        type User = User;
+
+        fn map(row: &rusqlite::Row<'_>) -> Result<Self::User, rusqlite::Error> {
+            Ok(User {
+                id: row.get(0)?,
+                password_hash: row.get(1)?,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_store() {
+        let conn = Connection::open_in_memory().await.unwrap();
+        let conn2 = conn.clone();
+        let store = RusqliteStore::<User, MyUserMapper>::new(conn);
+
+        conn2
+            .call(|conn| conn.execute("CREATE TABLE users(id NUMBER, password_hash TEXT);", []))
+            .await
+            .unwrap();
+
+        conn2
+            .call(|conn| conn.execute("INSERT INTO users VALUES (1, 'test');", []))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store.query,
+            "SELECT * FROM users WHERE id = :id".to_string()
+        );
+
+        let user = store.load_user(&1).await.unwrap().unwrap();
+        assert_eq!(
+            User {
+                id: 1,
+                password_hash: "test".to_string()
+            },
+            user
+        )
+    }
+
+    #[tokio::test]
+    async fn test_store_without_query_override_has_default_query() {
+        let conn = Connection::open_in_memory().await.unwrap();
+        let store = RusqliteStore::<User, MyUserMapper>::new(conn);
+        assert_eq!(
+            store.query,
+            "SELECT * FROM users WHERE id = :id".to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_store_full_query_override() {
+        let conn = Connection::open_in_memory().await.unwrap();
+        let store = RusqliteStore::<User, MyUserMapper>::new(conn).with_query("select 1 from foo");
+        assert_eq!(store.query, "select 1 from foo".to_string());
+    }
+}


### PR DESCRIPTION
This PR provides a `rusqlite` compatible store based on `tokio-rusqlite`. 

# TODO
- [x] Currently this PR does not compile due to a `libsqlite3-sys` linking problem which I'm not yet sure how to solve. It occurs even when the `sqlx` feature is disabled, which is rather surprising:

```
error: failed to select a version for `libsqlite3-sys`.
    ... required by package `sqlx-core v0.6.3`
    ... which satisfies dependency `sqlx-core = "^0.6.3"` (locked to 0.6.3) of package `sqlx v0.6.3`
    ... which satisfies dependency `sqlx = "^0.6"` (locked to 0.6.3) of package `axum-login v0.5.0 (/var/home/czocher/Projekty/axum-login/axum-login)`
    ... which satisfies path dependency `axum-login` (locked to 0.5.0) of package `axum_login_tests v0.4.1 (/var/home/czocher/Projekty/axum-login/axum-login-tests)`
versions that meet the requirements `^0.24.1` are: 0.24.2, 0.24.1

the package `libsqlite3-sys` links to the native library `sqlite3`, but it conflicts with a previous package which links to `sqlite3` as well:
package `libsqlite3-sys v0.26.0`
    ... which satisfies dependency `libsqlite3-sys = "^0.26.0"` (locked to 0.26.0) of package `rusqlite v0.29.0`
    ... which satisfies dependency `rusqlite = "^0.29.0"` (locked to 0.29.0) of package `axum-login v0.5.0 (/var/home/czocher/Projekty/axum-login/axum-login)`
    ... which satisfies path dependency `axum-login` (locked to 0.5.0) of package `axum_login_tests v0.4.1 (/var/home/czocher/Projekty/axum-login/axum-login-tests)`
Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the links ='libsqlite3-sys' value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.

failed to select a version for `libsqlite3-sys` which could resolve this conflict
```

Closes #35