### PR TITLE
Update sqlx to 0.7.1, which removes mssql support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **BREAKING CHANGES**:
 
 - Use associated type `Error` in `UserStore` instead of eyre for error handling [#69](https://github.com/maxcountryman/axum-login/pull/69)
+- Update to `sqlx` to 0.7, which [drops support for MS SQL Server](https://github.com/launchbadge/sqlx/pull/2039)
 
 # 0.5.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,5 @@ members = [
     "axum-login",
     "axum-login-tests",
 ]
+
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To use the crate in your project, add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-axum-login = "0.5.0"
+axum-login = "0.6.0"
 ```
 
 ## 🤸 Usage

--- a/axum-login-tests/Cargo.toml
+++ b/axum-login-tests/Cargo.toml
@@ -12,12 +12,11 @@ publish = false
 [dependencies]
 axum-login = { path = "../axum-login", features = [
     "sqlx",
-    "mssql",
     "mysql",
     "postgres",
     "sqlite",
 ] }
-sqlx = { version = "0.6" }
+sqlx = { version = "0.7.1" }
 
 [features]
 mysql = ["axum-login/mysql"]

--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -21,7 +21,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []
-mssql = ["sqlx/mssql"]
 mysql = ["sqlx/mysql"]
 postgres = ["sqlx/postgres"]
 sqlite = ["sqlx/sqlite"]
@@ -37,7 +36,7 @@ futures = "0.3"
 ring = "0.16"
 serde = "1"
 serde_json = "1"
-sqlx = { version = "0.6", optional = true }
+sqlx = { version = "0.7.1", optional = true }
 tokio = { version = "1.20", features = ["sync"] }
 tower = "0.4"
 tower-http = { version = "0.4", features = ["auth"] }

--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-login"
-version = "0.5.0"
+version = "0.6.0"
 description = "🪪 Session-based user authentication for Axum."
 edition = "2021"
 homepage = "https://github.com/maxcountryman/axum-login"

--- a/axum-login/src/lib.rs
+++ b/axum-login/src/lib.rs
@@ -184,8 +184,6 @@ pub use auth::{AuthLayer, RequireAuthorizationLayer};
 pub use auth_user::AuthUser;
 pub use axum_sessions;
 pub use secrecy;
-#[cfg(feature = "mssql")]
-pub use sqlx_store::MssqlStore;
 #[cfg(feature = "mysql")]
 pub use sqlx_store::MySqlStore;
 #[cfg(feature = "postgres")]

--- a/axum-login/src/sqlx_store.rs
+++ b/axum-login/src/sqlx_store.rs
@@ -1,8 +1,6 @@
 use std::marker::{PhantomData, Unpin};
 
 use async_trait::async_trait;
-#[cfg(feature = "mssql")]
-use sqlx::{mssql::MssqlRow, Mssql, MssqlPool};
 #[cfg(feature = "mysql")]
 use sqlx::{mysql::MySqlRow, MySql, MySqlPool};
 #[cfg(feature = "postgres")]
@@ -87,21 +85,15 @@ macro_rules! impl_user_store {
             type Error = sqlx::error::Error;
 
             async fn load_user(&self, user_id: &UserId) -> Result<Option<Self::User>, Self::Error> {
-                let mut connection = self.pool.acquire().await?;
-
                 let user: Option<User> = sqlx::query_as(&self.query)
                     .bind(&user_id)
-                    .fetch_optional(&mut connection)
+                    .fetch_optional(&self.pool)
                     .await?;
                 Ok(user)
             }
         }
     };
 }
-
-/// A Mssql user store via sqlx.
-#[cfg(feature = "mssql")]
-pub type MssqlStore<User, Role = ()> = SqlxStore<MssqlPool, User, Role>;
 
 /// A MySql user store via sqlx.
 #[cfg(feature = "mysql")]
@@ -115,8 +107,6 @@ pub type PostgresStore<User, Role = ()> = SqlxStore<PgPool, User, Role>;
 #[cfg(feature = "sqlite")]
 pub type SqliteStore<User, Role = ()> = SqlxStore<SqlitePool, User, Role>;
 
-#[cfg(feature = "mssql")]
-impl_user_store!(Mssql, MssqlStore, MssqlRow);
 #[cfg(feature = "mysql")]
 impl_user_store!(MySql, MySqlStore, MySqlRow);
 #[cfg(feature = "postgres")]

--- a/examples/oauth/Cargo.toml
+++ b/examples/oauth/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.8.5"
 features = ["min_const_gen"]
 
 [dependencies.sqlx]
-version = "0.6.1"
+version = "0.7.1"
 default-features = false
 features = ["runtime-tokio-rustls", "sqlite"]
 

--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -128,15 +128,10 @@ async fn oauth_callback_handler(
         .await
         .unwrap();
 
-    // Do something with the token
-    // ...
-    println!("Getting db connection");
-
     // Fetch the user and log them in
-    let mut conn = pool.acquire().await.unwrap();
     println!("Getting user");
     let user: User = sqlx::query_as("select * from users where id = 1")
-        .fetch_one(&mut conn)
+        .fetch_one(&pool)
         .await
         .unwrap();
     println!("Got user {user:?}. Logging in.");

--- a/examples/sqlite/Cargo.toml
+++ b/examples/sqlite/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.8.5"
 features = ["min_const_gen"]
 
 [dependencies.sqlx]
-version = "0.6.1"
+version = "0.7.1"
 default-features = false
 features = ["runtime-tokio-rustls", "sqlite"]
 

--- a/examples/sqlite/src/main.rs
+++ b/examples/sqlite/src/main.rs
@@ -52,9 +52,8 @@ async fn main() {
             .connect("sqlite/user_store.db")
             .await
             .unwrap();
-        let mut conn = pool.acquire().await.unwrap();
         let user: User = sqlx::query_as("select * from users where id = 1")
-            .fetch_one(&mut conn)
+            .fetch_one(&pool)
             .await
             .unwrap();
         auth.login(&user).await.unwrap();

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,3 +3,4 @@ format_strings = true
 imports_granularity = "Crate"
 group_imports = "StdExternalCrate"
 wrap_comments = true
+edition = "2021"


### PR DESCRIPTION
Hi there! The latest version of `sqlx`, 0.7, [dropped support for MSSQL Server](https://github.com/launchbadge/sqlx/pull/2039), but aside from that, was the only change needed to use it for the sqlx_store. Since that's potentially breaking, I updated the version of `axum-login` to 0.6.0.