### PR TITLE
#90 upgrade sqlx to 0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Provide `User` without `Option` [#70](https://github.com/maxcountryman/axum-login/pull/70)
 - Use associated type `Error` in `UserStore` instead of eyre for error handling [#69](https://github.com/maxcountryman/axum-login/pull/69)
 - Make `role_bounds` optional [#67](https://github.com/maxcountryman/axum-login/pull/67)
+- Update `sqlx` to 0.7, which [drops support for MS SQL Server](https://github.com/launchbadge/sqlx/pull/2039)
 
 **OTHER CHANGES**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+**BREAKING CHANGES**:
+
+- Update `sqlx` to 0.7, which [drops support for MS SQL Server](https://github.com/launchbadge/sqlx/pull/2039)
+
 # 0.6.0
 
 **BREAKING CHANGES**:
@@ -7,7 +11,6 @@
 - Provide `User` without `Option` [#70](https://github.com/maxcountryman/axum-login/pull/70)
 - Use associated type `Error` in `UserStore` instead of eyre for error handling [#69](https://github.com/maxcountryman/axum-login/pull/69)
 - Make `role_bounds` optional [#67](https://github.com/maxcountryman/axum-login/pull/67)
-- Update `sqlx` to 0.7, which [drops support for MS SQL Server](https://github.com/launchbadge/sqlx/pull/2039)
 
 **OTHER CHANGES**
 

--- a/axum-login-tests/Cargo.toml
+++ b/axum-login-tests/Cargo.toml
@@ -12,12 +12,11 @@ publish = false
 [dependencies]
 axum-login = { path = "../axum-login", features = [
     "sqlx",
-    "mssql",
     "mysql",
     "postgres",
     "sqlite",
 ] }
-sqlx = { version = "0.6" }
+sqlx = { version = "0.7" }
 
 [features]
 mysql = ["axum-login/mysql"]

--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -22,7 +22,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []
-mssql = ["sqlx/mssql"]
 mysql = ["sqlx/mysql"]
 postgres = ["sqlx/postgres"]
 sqlite = ["sqlx/sqlite"]
@@ -33,12 +32,12 @@ async-trait = "0.1.57"
 axum = "0.6"
 axum-sessions = "0.5"
 percent-encoding = "2.2"
-base64 = "0.13"
+base64 = "0.21.3"
 futures = "0.3"
 ring = "0.16"
 serde = "1"
 serde_json = "1"
-sqlx = { version = "0.6", optional = true }
+sqlx = { version = "0.7", optional = true }
 tokio = { version = "1.20", features = ["sync"] }
 tower = "0.4"
 tower-http = { version = "0.4", features = ["auth"] }

--- a/axum-login/src/extractors.rs
+++ b/axum-login/src/extractors.rs
@@ -4,10 +4,10 @@ use std::marker::PhantomData;
 
 use axum::{async_trait, extract::FromRequestParts, http::request::Parts, Extension};
 use axum_sessions::SessionHandle;
+use base64::{engine::general_purpose, Engine as _};
 use ring::hmac::{self, Key};
 use secrecy::ExposeSecret;
 use serde::{de::DeserializeOwned, Serialize};
-use base64::{Engine as _, engine::general_purpose};
 
 use crate::{user_store::UserStore, AuthUser};
 

--- a/axum-login/src/lib.rs
+++ b/axum-login/src/lib.rs
@@ -184,8 +184,6 @@ pub use auth::{AuthLayer, RequireAuthorizationLayer};
 pub use auth_user::AuthUser;
 pub use axum_sessions;
 pub use secrecy;
-#[cfg(feature = "mssql")]
-pub use sqlx_store::MssqlStore;
 #[cfg(feature = "mysql")]
 pub use sqlx_store::MySqlStore;
 #[cfg(feature = "postgres")]

--- a/axum-login/src/sqlx_store.rs
+++ b/axum-login/src/sqlx_store.rs
@@ -91,7 +91,7 @@ macro_rules! impl_user_store {
 
                 let user: Option<User> = sqlx::query_as(&self.query)
                     .bind(&user_id)
-                    .fetch_optional(&mut connection)
+                    .fetch_optional(connection.as_mut())
                     .await?;
                 Ok(user)
             }

--- a/examples/oauth/Cargo.toml
+++ b/examples/oauth/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.8.5"
 features = ["min_const_gen"]
 
 [dependencies.sqlx]
-version = "0.6.1"
+version = "0.7"
 default-features = false
 features = ["runtime-tokio-rustls", "sqlite"]
 

--- a/examples/oauth/src/main.rs
+++ b/examples/oauth/src/main.rs
@@ -133,10 +133,9 @@ async fn oauth_callback_handler(
     println!("Getting db connection");
 
     // Fetch the user and log them in
-    let mut conn = pool.acquire().await.unwrap();
     println!("Getting user");
     let user: User = sqlx::query_as("select * from users where id = 1")
-        .fetch_one(&mut conn)
+        .fetch_one(&pool)
         .await
         .unwrap();
     println!("Got user {user:?}. Logging in.");

--- a/examples/sqlite/Cargo.toml
+++ b/examples/sqlite/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.8.5"
 features = ["min_const_gen"]
 
 [dependencies.sqlx]
-version = "0.6.1"
+version = "0.7"
 default-features = false
 features = ["runtime-tokio-rustls", "sqlite"]
 

--- a/examples/sqlite/src/main.rs
+++ b/examples/sqlite/src/main.rs
@@ -52,9 +52,8 @@ async fn main() {
             .connect("sqlite/user_store.db")
             .await
             .unwrap();
-        let mut conn = pool.acquire().await.unwrap();
         let user: User = sqlx::query_as("select * from users where id = 1")
-            .fetch_one(&mut conn)
+            .fetch_one(&pool)
             .await
             .unwrap();
         auth.login(&user).await.unwrap();


### PR DESCRIPTION
axum-login is not compatible with the latest version of sqlx (0.7.1) 

This PR upgrades the sqlx dependency to 0.7

* In addition base64 was upgraded to the latest version
* mssql was removed because sqlx don't support it in the 0.7 version

This fixes issue #90 

I did't see the earlier PR when I wrote this one - but in any case it seems to have merge conflict with main - but feel free to take this one or the earlier one if you prefer.