### PR TITLE
wip: async-session-v4

### DIFF
--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -30,7 +30,9 @@ sqlx = ["sqlx/runtime-tokio-rustls"]
 [dependencies]
 async-trait = "0.1.57"
 axum = "0.6"
-axum-sessions = "0.5"
+
+axum-sessions = { git = "https://github.com/sbihel/axum-sessions.git", branch = "main" }
+
 percent-encoding = "2.2"
 base64 = "0.21.3"
 futures = "0.3"

--- a/axum-login/src/extractors.rs
+++ b/axum-login/src/extractors.rs
@@ -68,7 +68,7 @@ where
     }
 
     pub(super) async fn get_user(&mut self) -> Result<Option<User>, Store::Error> {
-        let session = self.session_handle.read().await;
+        let session = self.session_handle.lock().await;
 
         if let Some(user_id) = session.get::<UserId>(SESSION_USER_ID_KEY) {
             if let Some(user) = self.store.load_user(&user_id).await? {
@@ -103,7 +103,7 @@ where
         let auth_id = self.get_session_auth_id(user.get_password_hash().expose_secret());
         let user_id = user.get_id();
 
-        let mut session = self.session_handle.write().await;
+        let mut session = self.session_handle.lock().await;
         session.insert(SESSION_AUTH_ID_KEY, auth_id)?;
         session.insert(SESSION_USER_ID_KEY, user_id)?;
 
@@ -117,7 +117,7 @@ where
     /// Subsequent requests will not provide an authenticated session until
     /// `login` is invoked again.
     pub async fn logout(&mut self) {
-        let mut session = self.session_handle.write().await;
+        let mut session = self.session_handle.lock().await;
         session.destroy();
     }
 }


### PR DESCRIPTION
This complements work upstream with `axum-sessions` to migrate to `async-session-v4` once it's released.