### PR TITLE
ensure anonymous sessions are verified

### DIFF
--- a/axum-login/src/session.rs
+++ b/axum-login/src/session.rs
@@ -150,7 +150,7 @@ impl<Backend: AuthnBackend> AuthSession<Backend> {
 
         if let Some(ref authed_user) = user {
             let session_auth_hash = authed_user.session_auth_hash();
-            let session_verified = &data.clone().auth_hash.is_some_and(|auth_hash| {
+            let session_verified = &data.auth_hash.clone().is_some_and(|auth_hash| {
                 verify_slices_are_equal(&auth_hash[..], session_auth_hash).is_ok()
             });
             if !session_verified {

--- a/axum-login/tests/integration-test.rs
+++ b/axum-login/tests/integration-test.rs
@@ -32,7 +32,7 @@ async fn start_example_binary() -> ChildGuard {
     let start_time = Instant::now();
     let mut is_server_ready = false;
 
-    while start_time.elapsed() < Duration::from_secs(30) {
+    while start_time.elapsed() < Duration::from_secs(300) {
         if reqwest::get(WEBSERVER_URL).await.is_ok() {
             is_server_ready = true;
             break;


### PR DESCRIPTION
This patch differentiates between sessions that have already been authenticated and those that have not when verifying a session. This distinction is important because when a logged in user's session cannot be verified we must flush the session. However, before a user is logged in we should avoid unnecessarily removing session data.