### PR TITLE
Replace ring dependency with a compare function

### DIFF
--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -20,7 +20,7 @@ readme = "../README.md"
 async-trait = "0.1.57"
 axum = { version = "0.6.20", default-features = false }
 http = "0.2.9"
-ring = "0.17.5"
+##ring = "0.17.5"
 serde = "1"
 thiserror = "1.0.49"
 tower-cookies = "0.9.0"

--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -19,7 +19,7 @@ readme = "../README.md"
 [dependencies]
 async-trait = "0.1.57"
 axum = { version = "0.6.20", default-features = false }
-http = "0.2.9"
+##http = "0.2.9"
 ##ring = "0.17.5"
 serde = "1"
 thiserror = "1.0.49"

--- a/axum-login/src/extract.rs
+++ b/axum-login/src/extract.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum::extract::FromRequestParts;
-use http::{request::Parts, StatusCode};
+use axum::http::{request::Parts, StatusCode};
 
 use crate::{AuthSession, AuthnBackend};
 
@@ -10,7 +10,7 @@ where
     S: Send + Sync,
     Backend: AuthnBackend + Send + Sync + 'static,
 {
-    type Rejection = (http::StatusCode, &'static str);
+    type Rejection = (StatusCode, &'static str);
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         parts.extensions.get::<AuthSession<_>>().cloned().ok_or((

--- a/axum-login/src/lib.rs
+++ b/axum-login/src/lib.rs
@@ -170,7 +170,7 @@
 //!     response::{IntoResponse, Redirect},
 //!     Form,
 //! };
-//! use http::StatusCode;
+//! use axum::http::StatusCode;
 //!
 //! type AuthSession = axum_login::AuthSession<Backend>;
 //!
@@ -346,7 +346,7 @@
 //!     BoxError, Form, Router,
 //! };
 //! use axum_login::{login_required, AuthManagerLayerBuilder};
-//! use http::StatusCode;
+//! use axum::http::StatusCode;
 //! use tower::ServiceBuilder;
 //! use tower_sessions::{MemoryStore, SessionManagerLayer};
 //!
@@ -398,8 +398,8 @@
 #![forbid(unsafe_code)]
 
 pub use axum;
+pub use axum::http;
 pub use backend::{AuthUser, AuthnBackend, AuthzBackend, UserId};
-pub use http;
 pub use service::{AuthManager, AuthManagerLayer, AuthManagerLayerBuilder};
 pub use session::{AuthSession, Error};
 pub use tower_sessions;

--- a/axum-login/src/service.rs
+++ b/axum-login/src/service.rs
@@ -5,7 +5,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use http::{Request, Response};
+use axum::http::{Request, Response};
 use tower_cookies::CookieManager;
 use tower_layer::Layer;
 use tower_service::Service;

--- a/axum-login/src/session.rs
+++ b/axum-login/src/session.rs
@@ -1,6 +1,6 @@
-use std::fmt::Debug;
 
-use ring::constant_time::verify_slices_are_equal;
+use std::fmt::Debug;
+//use ring::constant_time::verify_slices_are_equal;
 use serde::{Deserialize, Serialize};
 use tower_sessions::{session, Session};
 
@@ -8,6 +8,19 @@ use crate::{
     backend::{AuthUser, UserId},
     AuthnBackend,
 };
+
+fn compare(a: &[u8], b: &[u8]) -> core::cmp::Ordering {
+    for (ai, bi) in a.iter().zip(b.iter()) {
+        match ai.cmp(&bi) {
+            core::cmp::Ordering::Equal => continue,
+            ord => return ord
+        }
+    }
+
+    /* if every single element was equal, compare length */
+    a.len().cmp(&b.len())
+}
+
 
 /// An error type which maps session and backend errors.
 #[derive(thiserror::Error)]
@@ -157,7 +170,8 @@ impl<Backend: AuthnBackend> AuthSession<Backend> {
         if let Some(ref authed_user) = user {
             let session_auth_hash = authed_user.session_auth_hash();
             let session_verified = &data.auth_hash.clone().is_some_and(|auth_hash| {
-                verify_slices_are_equal(&auth_hash[..], session_auth_hash).is_ok()
+                //verify_slices_are_equal(&auth_hash[..], session_auth_hash).is_ok()
+                compare(&auth_hash[..],session_auth_hash) == core::cmp::Ordering::Equal
             });
             if !session_verified {
                 user = None;

--- a/axum-login/src/session.rs
+++ b/axum-login/src/session.rs
@@ -1,6 +1,5 @@
 
 use std::fmt::Debug;
-//use ring::constant_time::verify_slices_are_equal;
 use serde::{Deserialize, Serialize};
 use tower_sessions::{session, Session};
 
@@ -170,7 +169,6 @@ impl<Backend: AuthnBackend> AuthSession<Backend> {
         if let Some(ref authed_user) = user {
             let session_auth_hash = authed_user.session_auth_hash();
             let session_verified = &data.auth_hash.clone().is_some_and(|auth_hash| {
-                //verify_slices_are_equal(&auth_hash[..], session_auth_hash).is_ok()
                 compare(&auth_hash[..],session_auth_hash) == core::cmp::Ordering::Equal
             });
             if !session_verified {

--- a/axum-login/src/session.rs
+++ b/axum-login/src/session.rs
@@ -11,7 +11,7 @@ use crate::{
 
 fn compare(a: &[u8], b: &[u8]) -> core::cmp::Ordering {
     for (ai, bi) in a.iter().zip(b.iter()) {
-        match ai.cmp(&bi) {
+        match ai.cmp(bi) {
             core::cmp::Ordering::Equal => continue,
             ord => return ord
         }

--- a/examples/oauth2/src/users.rs
+++ b/examples/oauth2/src/users.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use axum_login::{AuthUser, AuthnBackend, UserId};
-use http::header::{AUTHORIZATION, USER_AGENT};
+use axum::http::header::{AUTHORIZATION, USER_AGENT};
 use oauth2::{
     basic::{BasicClient, BasicRequestTokenError},
     reqwest::{async_http_client, AsyncHttpClientError},

--- a/examples/oauth2/src/web/app.rs
+++ b/examples/oauth2/src/web/app.rs
@@ -6,7 +6,7 @@ use axum_login::{
     tower_sessions::{cookie::SameSite, Expiry, MemoryStore, SessionManagerLayer},
     AuthManagerLayerBuilder,
 };
-use http::StatusCode;
+use axum::http::StatusCode;
 use oauth2::{basic::BasicClient, AuthUrl, ClientId, ClientSecret, TokenUrl};
 use sqlx::SqlitePool;
 use time::Duration;

--- a/examples/oauth2/src/web/auth.rs
+++ b/examples/oauth2/src/web/auth.rs
@@ -6,7 +6,7 @@ use axum::{
     Form, Router,
 };
 use axum_login::tower_sessions::Session;
-use http::StatusCode;
+use axum::http::StatusCode;
 use serde::Deserialize;
 
 use crate::{users::AuthSession, web::oauth::CSRF_STATE_KEY};

--- a/examples/oauth2/src/web/oauth.rs
+++ b/examples/oauth2/src/web/oauth.rs
@@ -5,7 +5,7 @@ use axum::{
     Router,
 };
 use axum_login::tower_sessions::Session;
-use http::StatusCode;
+use axum::http::StatusCode;
 use oauth2::CsrfToken;
 use serde::Deserialize;
 

--- a/examples/oauth2/src/web/protected.rs
+++ b/examples/oauth2/src/web/protected.rs
@@ -1,6 +1,6 @@
 use askama::Template;
 use axum::{response::IntoResponse, routing::get, Router};
-use http::StatusCode;
+use axum::http::StatusCode;
 
 use crate::users::AuthSession;
 

--- a/examples/permissions/src/web/app.rs
+++ b/examples/permissions/src/web/app.rs
@@ -6,7 +6,7 @@ use axum_login::{
     tower_sessions::{Expiry, MemoryStore, SessionManagerLayer},
     AuthManagerLayerBuilder,
 };
-use http::StatusCode;
+use axum::http::StatusCode;
 use sqlx::SqlitePool;
 use time::Duration;
 use tower::ServiceBuilder;

--- a/examples/permissions/src/web/auth.rs
+++ b/examples/permissions/src/web/auth.rs
@@ -5,7 +5,7 @@ use axum::{
     routing::{get, post},
     Form, Router,
 };
-use http::StatusCode;
+use axum::http::StatusCode;
 use serde::Deserialize;
 
 use crate::users::{AuthSession, Credentials};

--- a/examples/permissions/src/web/protected.rs
+++ b/examples/permissions/src/web/protected.rs
@@ -1,6 +1,6 @@
 use askama::Template;
 use axum::{response::IntoResponse, routing::get, Router};
-use http::StatusCode;
+use axum::http::StatusCode;
 
 use crate::users::AuthSession;
 

--- a/examples/permissions/src/web/restricted.rs
+++ b/examples/permissions/src/web/restricted.rs
@@ -1,6 +1,6 @@
 use askama::Template;
 use axum::{response::IntoResponse, routing::get, Router};
-use http::StatusCode;
+use axum::http::StatusCode;
 
 use crate::users::AuthSession;
 

--- a/examples/sqlite/src/web/app.rs
+++ b/examples/sqlite/src/web/app.rs
@@ -6,7 +6,7 @@ use axum_login::{
     tower_sessions::{Expiry, MemoryStore, SessionManagerLayer},
     AuthManagerLayerBuilder,
 };
-use http::StatusCode;
+use axum::http::StatusCode;
 use sqlx::SqlitePool;
 use time::Duration;
 use tower::ServiceBuilder;

--- a/examples/sqlite/src/web/auth.rs
+++ b/examples/sqlite/src/web/auth.rs
@@ -5,7 +5,7 @@ use axum::{
     routing::{get, post},
     Form, Router,
 };
-use http::StatusCode;
+use axum::http::StatusCode;
 use serde::Deserialize;
 
 use crate::users::{AuthSession, Credentials};

--- a/examples/sqlite/src/web/protected.rs
+++ b/examples/sqlite/src/web/protected.rs
@@ -1,6 +1,6 @@
 use askama::Template;
 use axum::{response::IntoResponse, routing::get, Router};
-use http::StatusCode;
+use axum::http::StatusCode;
 
 use crate::users::AuthSession;
 


### PR DESCRIPTION
cargo.tml has ring = "0.17.5" as a dependency. So far as I can see it is used only in session.rs and only once in line 160
```
                verify_slices_are_equal(&auth_hash[..], session_auth_hash).is_ok()
```

I wanted to try to compare the password hashes in a way that does not require a dependency that uses unsafe rust code and a C library.  So using an example I found on stack exchange I have these changes to session.rs
```
//use ring::constant_time::verify_slices_are_equal;
```
Stack Exchange link to the code below: https://codereview.stackexchange.com/a/233876
```
// new compare function
fn compare(a: &[u8], b: &[u8]) -> core::cmp::Ordering {
    for (ai, bi) in a.iter().zip(b.iter()) {
        match ai.cmp(&bi) {
            core::cmp::Ordering::Equal => continue,
            ord => return ord
        }
    }

    /* if every single element was equal, compare length */
    a.len().cmp(&b.len())
}
```

then in `pub(crate) async fn from_session(` I have
```
            let session_verified = &data.auth_hash.clone().is_some_and(|auth_hash| {
                //verify_slices_are_equal(&auth_hash[..], session_auth_hash).is_ok()
                compare(&auth_hash[..],session_auth_hash) == core::cmp::Ordering::Equal
            });
```

I have also commented out the dependency in cargo.tml

It works with the sqlite example. No idea how performance compares.