### PR TITLE
update tower-sessions

### DIFF
--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -18,21 +18,21 @@ readme = "../README.md"
 
 [dependencies]
 async-trait = "0.1.57"
-axum = { version = "0.6.20", default-features = false }
+axum = { version = "0.7.1", default-features = false }
 ring = "0.17.5"
 serde = "1"
 thiserror = "1.0.49"
-tower-cookies = "0.9.0"
+tower-cookies = "0.10.0"
 tower-layer = "0.3.2"
 tower-service = "0.3.2"
-tower-sessions = "0.6.0"
+tower-sessions = "0.7.0"
 tracing = { version = "0.1.40", features = ["log"] }
 urlencoding = "2.1.3"
 
 [dev-dependencies]
-axum = "0.6.20"
+axum = "0.7.0"
 reqwest = { version = "0.11.22", features = ["cookies"] }
 tokio = { version = "1.32.0", features = ["full"] }
 tokio-test = "0.4.3"
 tower = "0.4.13"
-tower-sessions = "0.6.0"
+tower-sessions = "0.7.0"

--- a/axum-login/src/lib.rs
+++ b/axum-login/src/lib.rs
@@ -337,8 +337,6 @@
 //! #         Ok(self.users.get(user_id).cloned())
 //! #     }
 //! # }
-//! use std::net::SocketAddr;
-//!
 //! use axum::{
 //!     error_handling::HandleErrorLayer,
 //!     http::StatusCode,
@@ -371,10 +369,8 @@
 //!         .route("/login", get(todo!()))
 //!         .layer(auth_service);
 //!
-//!     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-//!     axum::Server::bind(&addr)
-//!         .serve(app.into_make_service())
-//!         .await?;
+//!     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+//!     axum::serve(listener, app.into_make_service()).await?;
 //!
 //!     Ok(())
 //! }

--- a/axum-login/src/middleware.rs
+++ b/axum-login/src/middleware.rs
@@ -21,7 +21,6 @@ macro_rules! login_required {
         }
 
         $crate::predicate_required!(
-            $backend_type,
             is_authenticated,
             login_url = $login_url,
             redirect_field = $redirect_field
@@ -62,7 +61,6 @@ macro_rules! permission_required {
         }
 
         $crate::predicate_required!(
-            $backend_type,
             is_authorized,
             login_url = $login_url,
             redirect_field = $redirect_field
@@ -95,7 +93,6 @@ macro_rules! permission_required {
         }
 
         $crate::predicate_required!(
-            $backend_type,
             is_authorized,
             $crate::http::StatusCode::FORBIDDEN
         )
@@ -112,14 +109,14 @@ macro_rules! permission_required {
 /// used as the response.
 #[macro_export]
 macro_rules! predicate_required {
-    ($backend_type:ty, $predicate:expr, $alternative:expr) => {{
+    ($predicate:expr, $alternative:expr) => {{
         use $crate::axum::{
             middleware::{from_fn, Next},
             response::{IntoResponse, Redirect},
         };
 
         from_fn(
-            |auth_session: $crate::AuthSession<$backend_type>, req, next: Next<_>| async move {
+            |auth_session: $crate::AuthSession<_>, req, next: Next| async move {
                 if $predicate(auth_session).await {
                     next.run(req).await
                 } else {
@@ -129,14 +126,14 @@ macro_rules! predicate_required {
         )
     }};
 
-    ($backend_type:ty, $predicate:expr, login_url = $login_url:expr, redirect_field = $redirect_field:expr) => {{
+    ($predicate:expr, login_url = $login_url:expr, redirect_field = $redirect_field:expr) => {{
         use $crate::axum::{
             middleware::{from_fn, Next},
             response::{IntoResponse, Redirect},
         };
 
         from_fn(
-            |auth_session: $crate::AuthSession<$backend_type>, req, next: Next<_>| async move {
+            |auth_session: $crate::AuthSession<_>, req, next: Next| async move {
                 if $predicate(auth_session).await {
                     next.run(req).await
                 } else {

--- a/axum-login/src/service.rs
+++ b/axum-login/src/service.rs
@@ -122,7 +122,8 @@ pub struct AuthManagerLayerBuilder<Backend: AuthnBackend, Sessions: SessionStore
 }
 
 impl<Backend: AuthnBackend, Sessions: SessionStore> AuthManagerLayerBuilder<Backend, Sessions> {
-    /// Create a new [`AuthManagerLayerBuilder`] with the provided access controller.
+    /// Create a new [`AuthManagerLayerBuilder`] with the provided access
+    /// controller.
     pub fn new(backend: Backend, session_manager_layer: SessionManagerLayer<Sessions>) -> Self {
         Self {
             backend,
@@ -131,7 +132,8 @@ impl<Backend: AuthnBackend, Sessions: SessionStore> AuthManagerLayerBuilder<Back
         }
     }
 
-    /// Configure the `data_key` optional property of the builder. If not configured it will default to "axum-login.data".
+    /// Configure the `data_key` optional property of the builder. If not
+    /// configured it will default to "axum-login.data".
     pub fn with_data_key(
         mut self,
         data_key: &'static str,

--- a/examples/oauth2/Cargo.toml
+++ b/examples/oauth2/Cargo.toml
@@ -6,19 +6,19 @@ publish = false
 
 [dependencies]
 askama = { version = "0.12.1", features = ["with-axum"] }
-askama_axum = "0.3.0"
-async-trait = "0.1.57"
-axum = "0.6.20"
+askama_axum = "0.4.0"
+async-trait = "0.1.74"
+axum = "0.7.1"
 axum-login = { path = "../../axum-login" }
 dotenvy = "0.15.7"
-http = "0.2.9"
-hyper = "0.14.27"
+http = "1.0.0"
+hyper = "1.0.1"
 oauth2 = "4.4.2"
 reqwest = { version = "0.11.22", features = ["json"] }
 serde = "1"
-sqlx = { version = "0.7.2", features = ["sqlite", "time", "runtime-tokio"] }
+sqlx = { version = "0.7.3", features = ["sqlite", "time", "runtime-tokio"] }
 thiserror = "1.0.50"
 time = "0.3.30"
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.34.0", features = ["full"] }
 tower = "0.4.13"
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/examples/oauth2/src/users.rs
+++ b/examples/oauth2/src/users.rs
@@ -107,9 +107,9 @@ impl AuthnBackend for Backend {
         // Use access token to request user info.
         let user_info = reqwest::Client::new()
             .get("https://api.github.com/user")
-            .header(USER_AGENT, "axum-login") // See: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#user-agent-required
+            .header(USER_AGENT.as_str(), "axum-login") // See: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#user-agent-required
             .header(
-                AUTHORIZATION,
+                AUTHORIZATION.as_str(),
                 format!("Bearer {}", token_res.access_token().secret()),
             )
             .send()

--- a/examples/oauth2/src/web/app.rs
+++ b/examples/oauth2/src/web/app.rs
@@ -1,7 +1,6 @@
-use std::{env, net::SocketAddr};
+use std::env;
 
-use axum::http::StatusCode;
-use axum::{error_handling::HandleErrorLayer, BoxError};
+use axum::{error_handling::HandleErrorLayer, http::StatusCode, BoxError};
 use axum_login::{
     login_required,
     tower_sessions::{cookie::SameSite, Expiry, MemoryStore, SessionManagerLayer},
@@ -44,8 +43,6 @@ impl App {
     }
 
     pub async fn serve(self) -> Result<(), Box<dyn std::error::Error>> {
-        let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-
         // Session layer.
         //
         // This uses `tower-sessions` to establish a layer that will provide the session
@@ -73,9 +70,8 @@ impl App {
             .merge(oauth::router())
             .layer(auth_service);
 
-        axum::Server::bind(&addr)
-            .serve(app.into_make_service())
-            .await?;
+        let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+        axum::serve(listener, app.into_make_service()).await?;
 
         Ok(())
     }

--- a/examples/permissions/Cargo.toml
+++ b/examples/permissions/Cargo.toml
@@ -6,16 +6,16 @@ publish = false
 
 [dependencies]
 askama = { version = "0.12.1", features = ["with-axum"] }
-askama_axum = "0.3.0"
-async-trait = "0.1.57"
-axum = "0.6.20"
+askama_axum = "0.4.0"
+async-trait = "0.1.74"
+axum = "0.7.1"
 axum-login = { path = "../../axum-login" }
-http = "0.2.9"
-hyper = "0.14.27"
+http = "1.0.0"
+hyper = "1.0.1"
 password-auth = "1.0.0"
 serde = "1"
-sqlx = { version = "0.7.2", features = ["sqlite", "time", "runtime-tokio"] }
+sqlx = { version = "0.7.3", features = ["sqlite", "time", "runtime-tokio"] }
 time = "0.3.30"
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.34.0", features = ["full"] }
 tower = "0.4.13"
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/examples/permissions/src/web/app.rs
+++ b/examples/permissions/src/web/app.rs
@@ -1,7 +1,4 @@
-use std::net::SocketAddr;
-
-use axum::http::StatusCode;
-use axum::{error_handling::HandleErrorLayer, BoxError};
+use axum::{error_handling::HandleErrorLayer, http::StatusCode, BoxError};
 use axum_login::{
     permission_required,
     tower_sessions::{Expiry, MemoryStore, SessionManagerLayer},
@@ -29,8 +26,6 @@ impl App {
     }
 
     pub async fn serve(self) -> Result<(), Box<dyn std::error::Error>> {
-        let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-
         // Session layer.
         //
         // This uses `tower-sessions` to establish a layer that will provide the session
@@ -66,9 +61,8 @@ impl App {
             .merge(auth::router())
             .layer(auth_service);
 
-        axum::Server::bind(&addr)
-            .serve(app.into_make_service())
-            .await?;
+        let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+        axum::serve(listener, app.into_make_service()).await?;
 
         Ok(())
     }

--- a/examples/sqlite/Cargo.toml
+++ b/examples/sqlite/Cargo.toml
@@ -6,16 +6,16 @@ publish = false
 
 [dependencies]
 askama = { version = "0.12.1", features = ["with-axum"] }
-askama_axum = "0.3.0"
-async-trait = "0.1.57"
-axum = "0.6.20"
+askama_axum = "0.4.0"
+async-trait = "0.1.74"
+axum = "0.7.0"
 axum-login = { path = "../../axum-login" }
-http = "0.2.9"
-hyper = "0.14.27"
+http = "1.0.0"
+hyper = "1.0.1"
 password-auth = "1.0.0"
 serde = "1"
-sqlx = { version = "0.7.2", features = ["sqlite", "time", "runtime-tokio"] }
+sqlx = { version = "0.7.3", features = ["sqlite", "time", "runtime-tokio"] }
 time = "0.3.30"
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.34.0", features = ["full"] }
 tower = "0.4.13"
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/examples/sqlite/src/web/app.rs
+++ b/examples/sqlite/src/web/app.rs
@@ -1,7 +1,4 @@
-use std::net::SocketAddr;
-
-use axum::http::StatusCode;
-use axum::{error_handling::HandleErrorLayer, BoxError};
+use axum::{error_handling::HandleErrorLayer, http::StatusCode, BoxError};
 use axum_login::{
     login_required,
     tower_sessions::{Expiry, MemoryStore, SessionManagerLayer},
@@ -29,8 +26,6 @@ impl App {
     }
 
     pub async fn serve(self) -> Result<(), Box<dyn std::error::Error>> {
-        let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-
         // Session layer.
         //
         // This uses `tower-sessions` to establish a layer that will provide the session
@@ -56,9 +51,8 @@ impl App {
             .merge(auth::router())
             .layer(auth_service);
 
-        axum::Server::bind(&addr)
-            .serve(app.into_make_service())
-            .await?;
+        let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+        axum::serve(listener, app.into_make_service()).await?;
 
         Ok(())
     }


### PR DESCRIPTION
This brings tower-sessions to 0.7.0, which includes support for axum 0.7 as well as http 1.0.