### PR TITLE
use original uri

### DIFF
--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -18,7 +18,9 @@ readme = "../README.md"
 
 [dependencies]
 async-trait = "0.1.57"
-axum = { version = "0.7.1", default-features = false }
+axum = { version = "0.7.1", default-features = false, features = [
+    "original-uri",
+] }
 ring = "0.17.5"
 serde = "1"
 thiserror = "1.0.49"


### PR DESCRIPTION
This addresses an issue where nested routes will truncate the prefix of a route when using the request URI directly.

See the axum documentation: https://docs.rs/axum/latest/axum/routing/struct.Router.html#how-the-uri-changes