### PR TITLE
ensure correct redirect uri query handling

### DIFF
--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -30,6 +30,7 @@ tower-service = "0.3.2"
 tower-sessions = "0.8.0"
 tracing = { version = "0.1.40", features = ["log"] }
 urlencoding = "2.1.3"
+form_urlencoded = "1.2.1"
 
 [dev-dependencies]
 axum = "0.7.0"

--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -34,7 +34,8 @@ urlencoding = "2.1.3"
 [dev-dependencies]
 axum = "0.7.0"
 reqwest = { version = "0.11.22", features = ["cookies"] }
+time = "0.3.31"
 tokio = { version = "1.32.0", features = ["full"] }
 tokio-test = "0.4.3"
 tower = "0.4.13"
-tower-sessions = "0.8.0"
+tower-sessions = { versopn = "0.8.0", features = ["sqlite-store"] }

--- a/axum-login/src/lib.rs
+++ b/axum-login/src/lib.rs
@@ -395,10 +395,12 @@
 
 pub use axum;
 pub use backend::{AuthUser, AuthnBackend, AuthzBackend, UserId};
+#[doc(hidden)]
+pub use middleware::url_with_redirect_query;
 pub use service::{AuthManager, AuthManagerLayer, AuthManagerLayerBuilder};
 pub use session::{AuthSession, Error};
 pub use tower_sessions;
-pub use urlencoding;
+pub use tracing;
 
 mod backend;
 mod extract;


### PR DESCRIPTION
This updates the way macros handle the redirect URI such that the query string is handled in a more correct way. Prior to this, the macros assumed no other query. Now we extend the query, if present, with the configured redirect field and URI.

Fixes https://github.com/maxcountryman/axum-login/issues/143.