### PR TITLE
make service infallible

### DIFF
--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -7,10 +7,10 @@ homepage = "https://github.com/maxcountryman/axum-login"
 license = "MIT"
 keywords = ["authentication", "authorization", "login", "axum", "sessions"]
 categories = [
-    "web-programming::http-server",
-    "web-programming",
-    "database",
-    "asynchronous",
+  "web-programming::http-server",
+  "web-programming",
+  "database",
+  "asynchronous",
 ]
 repository = "https://github.com/maxcountryman/axum-login"
 documentation = "https://docs.rs/axum-login"
@@ -19,7 +19,7 @@ readme = "../README.md"
 [dependencies]
 async-trait = "0.1.57"
 axum = { version = "0.7.1", default-features = false, features = [
-    "original-uri",
+  "original-uri",
 ] }
 ring = "0.17.5"
 serde = "1"
@@ -27,7 +27,7 @@ thiserror = "1.0.49"
 tower-cookies = "0.10.0"
 tower-layer = "0.3.2"
 tower-service = "0.3.2"
-tower-sessions = "0.8.0"
+tower-sessions = "0.9.0"
 tracing = { version = "0.1.40", features = ["log"] }
 urlencoding = "2.1.3"
 form_urlencoded = "1.2.1"
@@ -39,4 +39,4 @@ time = "0.3.31"
 tokio = { version = "1.32.0", features = ["full"] }
 tokio-test = "0.4.3"
 tower = "0.4.13"
-tower-sessions = { version = "0.8.0", features = ["sqlite-store"] }
+tower-sessions = { version = "0.9.0", features = ["sqlite-store"] }

--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -35,6 +35,7 @@ form_urlencoded = "1.2.1"
 [dev-dependencies]
 axum = "0.7.0"
 reqwest = { version = "0.11.22", features = ["cookies"] }
+serial_test = "2.0.0"
 time = "0.3.31"
 tokio = { version = "1.32.0", features = ["full"] }
 tokio-test = "0.4.3"

--- a/axum-login/src/lib.rs
+++ b/axum-login/src/lib.rs
@@ -338,15 +338,14 @@
 //! #     }
 //! # }
 //! use axum::{
-//!     error_handling::HandleErrorLayer,
-//!     http::StatusCode,
-//!     response::{IntoResponse, Redirect},
 //!     routing::{get, post},
-//!     BoxError, Form, Router,
+//!     Router,
 //! };
-//! use axum_login::{login_required, AuthManagerLayerBuilder};
-//! use tower::ServiceBuilder;
-//! use tower_sessions::{MemoryStore, SessionManagerLayer};
+//! use axum_login::{
+//!     login_required,
+//!     tower_sessions::{MemoryStore, SessionManagerLayer},
+//!     AuthManagerLayerBuilder,
+//! };
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -356,18 +355,14 @@
 //!
 //!     // Auth service.
 //!     let backend = Backend::default();
-//!     let auth_service = ServiceBuilder::new()
-//!         .layer(HandleErrorLayer::new(|_: BoxError| async {
-//!             StatusCode::BAD_REQUEST
-//!         }))
-//!         .layer(AuthManagerLayerBuilder::new(backend, session_layer).build());
+//!     let auth_layer = AuthManagerLayerBuilder::new(backend, session_layer).build();
 //!
 //!     let app = Router::new()
 //!         .route("/protected", get(todo!()))
 //!         .route_layer(login_required!(Backend, login_url = "/login"))
 //!         .route("/login", post(todo!()))
 //!         .route("/login", get(todo!()))
-//!         .layer(auth_service);
+//!         .layer(auth_layer);
 //!
 //!     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
 //!     axum::serve(listener, app.into_make_service()).await?;

--- a/axum-login/tests/integration-test.rs
+++ b/axum-login/tests/integration-test.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use reqwest::Client;
+use serial_test::serial;
 
 const WEBSERVER_URL: &str = "http://localhost:3000";
 
@@ -48,6 +49,7 @@ async fn start_example_binary(binary_name: &str) -> ChildGuard {
 }
 
 #[tokio::test]
+#[serial]
 async fn sqlite_example() {
     let _child_guard = start_example_binary("example-sqlite").await;
 
@@ -97,6 +99,7 @@ async fn sqlite_example() {
 }
 
 #[tokio::test]
+#[serial]
 async fn permissions_example() {
     let _child_guard = start_example_binary("example-permissions").await;
 

--- a/examples/sqlite/Cargo.toml
+++ b/examples/sqlite/Cargo.toml
@@ -19,3 +19,7 @@ time = "0.3.30"
 tokio = { version = "1.34.0", features = ["full"] }
 tower = "0.4.13"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tower-sessions = { version = "0.9.0", default-features = false, features = [
+    "sqlite-store",
+    "deletion-task",
+] }


### PR DESCRIPTION
This follows along with the upstream changes to `tower-sessions`, where we made it such that the sessions middleware will not directly result in an error.

Here we do the same and in doing so are able to use the layer directly with `axum`. This should reduce boilerplate.