### PR TITLE
provide user as a request extension

### DIFF
--- a/examples/sqlite/src/web/protected.rs
+++ b/examples/sqlite/src/web/protected.rs
@@ -1,12 +1,12 @@
 use askama::Template;
-use axum::{http::StatusCode, response::IntoResponse, routing::get, Router};
+use axum::{extract::Extension, response::IntoResponse, routing::get, Router};
 
-use crate::users::AuthSession;
+use crate::users::User;
 
 #[derive(Template)]
 #[template(path = "protected.html")]
-struct ProtectedTemplate<'a> {
-    username: &'a str,
+struct ProtectedTemplate {
+    username: String,
 }
 
 pub fn router() -> Router<()> {
@@ -16,14 +16,7 @@ pub fn router() -> Router<()> {
 mod get {
     use super::*;
 
-    pub async fn protected(auth_session: AuthSession) -> impl IntoResponse {
-        match auth_session.user {
-            Some(user) => ProtectedTemplate {
-                username: &user.username,
-            }
-            .into_response(),
-
-            None => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-        }
+    pub async fn protected(Extension(User { username, .. }): Extension<User>) -> impl IntoResponse {
+        ProtectedTemplate { username }
     }
 }


### PR DESCRIPTION
This provides the authenticated user, if there is one, as a request extension. Later applications may retrieve the user directly, e.g. via `axum::extract::Extenion`. This will fail in situations where there is not an authenticated user and therefore must be used only after authentication. For example, in routes protected by `login_required!`.