### PR TITLE
ensure sqlite example cleans up deletion task

### DIFF
--- a/examples/sqlite/src/web/app.rs
+++ b/examples/sqlite/src/web/app.rs
@@ -6,6 +6,7 @@ use axum_login::{
 use axum_messages::MessagesManagerLayer;
 use sqlx::SqlitePool;
 use time::Duration;
+use tokio::{signal, task::AbortHandle};
 use tower_sessions_sqlx_store::SqliteStore;
 
 use crate::{
@@ -57,10 +58,38 @@ impl App {
             .layer(auth_layer);
 
         let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-        axum::serve(listener, app.into_make_service()).await?;
+
+        // Ensure we use a shutdown signal to abort the deletion task.
+        axum::serve(listener, app.into_make_service())
+            .with_graceful_shutdown(shutdown_signal(deletion_task.abort_handle()))
+            .await?;
 
         deletion_task.await??;
 
         Ok(())
+    }
+}
+
+async fn shutdown_signal(deletion_task_abort_handle: AbortHandle) {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => { deletion_task_abort_handle.abort() },
+        _ = terminate => { deletion_task_abort_handle.abort() },
     }
 }


### PR DESCRIPTION
This augments the SQLite example to provide a shutdown signal which ensures that the deletion task is aborted.