### PR TITLE
update tower-sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+# 0.15.0
+
+- Update `tower-sessions` to 0.12.0
+
+As of this update, signed and encrypted session cookies are supported.
+
 # 0.14.0
 
 - Update `tower-sessions` to 0.11.0

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To use the crate in your project, add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-axum-login = "0.14.0"
+axum-login = "0.15.0"
 ```
 
 ## 🤸 Usage

--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-login"
-version = "0.14.0"
+version = "0.15.0"
 description = "🪪 User identification, authentication, and authorization for Axum."
 edition = "2021"
 homepage = "https://github.com/maxcountryman/axum-login"
@@ -27,7 +27,7 @@ thiserror = "1.0.49"
 tower-cookies = "0.10.0"
 tower-layer = "0.3.2"
 tower-service = "0.3.2"
-tower-sessions = "0.11.0"
+tower-sessions = "0.12.0"
 tracing = { version = "0.1.40", features = ["log"] }
 urlencoding = "2.1.3"
 form_urlencoded = "1.2.1"
@@ -40,5 +40,5 @@ time = "0.3.31"
 tokio = { version = "1.32.0", features = ["full"] }
 tokio-test = "0.4.3"
 tower = "0.4.13"
-tower-sessions = { version = "0.11.0" }
-tower-sessions-sqlx-store = { version = "0.11.0", features = ["sqlite"] }
+tower-sessions = { version = "0.12.0" }
+tower-sessions-sqlx-store = { version = "0.12.0", features = ["sqlite"] }

--- a/examples/sqlite/Cargo.toml
+++ b/examples/sqlite/Cargo.toml
@@ -10,7 +10,7 @@ askama_axum = "0.4.0"
 async-trait = "0.1.74"
 axum = "0.7.0"
 axum-login = { path = "../../axum-login" }
-axum-messages = "0.4.0"
+axum-messages = "0.6.0"
 http = "1.0.0"
 hyper = "1.0.1"
 password-auth = "1.0.0"
@@ -20,6 +20,8 @@ time = "0.3.30"
 tokio = { version = "1.34.0", features = ["full"] }
 tower = "0.4.13"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-tower-sessions = { version = "0.11.0", default-features = false }
-tower-sessions-sqlx-store = { version = "0.11.0", features = ["sqlite"] }
+tower-sessions = { version = "0.12.0", default-features = false, features = [
+    "signed",
+] }
+tower-sessions-sqlx-store = { version = "0.12.0", features = ["sqlite"] }
 thiserror = "1.0.56"

--- a/examples/sqlite/src/web/app.rs
+++ b/examples/sqlite/src/web/app.rs
@@ -7,6 +7,7 @@ use axum_messages::MessagesManagerLayer;
 use sqlx::SqlitePool;
 use time::Duration;
 use tokio::{signal, task::AbortHandle};
+use tower_sessions::cookie::Key;
 use tower_sessions_sqlx_store::SqliteStore;
 
 use crate::{
@@ -40,9 +41,13 @@ impl App {
                 .continuously_delete_expired(tokio::time::Duration::from_secs(60)),
         );
 
+        // Generate a cryptographic key to sign the session cookie.
+        let key = Key::generate();
+
         let session_layer = SessionManagerLayer::new(session_store)
             .with_secure(false)
-            .with_expiry(Expiry::OnInactivity(Duration::days(1)));
+            .with_expiry(Expiry::OnInactivity(Duration::days(1)))
+            .with_signed(key);
 
         // Auth service.
         //


### PR DESCRIPTION
This updates `tower-sessions` to `0.12.0`.

As of this update signed and encrypted sessions are supported.

Closes #198.