### PR TITLE
add test to sqlite example

### DIFF
--- a/examples/sqlite/Cargo.toml
+++ b/examples/sqlite/Cargo.toml
@@ -25,3 +25,6 @@ tower-sessions = { version = "0.12.0", default-features = false, features = [
 ] }
 tower-sessions-sqlx-store = { version = "0.12.0", features = ["sqlite"] }
 thiserror = "1.0.56"
+
+[dev-dependencies]
+serde_urlencoded = "0.7.1"

--- a/examples/sqlite/src/main.rs
+++ b/examples/sqlite/src/main.rs
@@ -7,6 +7,8 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilte
 
 use crate::web::App;
 
+#[cfg(test)]
+mod test;
 mod users;
 mod web;
 

--- a/examples/sqlite/src/test.rs
+++ b/examples/sqlite/src/test.rs
@@ -1,0 +1,67 @@
+use std::error::Error;
+
+use axum::Router;
+use axum_login::{login_required, AuthManagerLayerBuilder};
+use axum_messages::{Messages, MessagesManagerLayer};
+use http::{header::CONTENT_TYPE, Request};
+use sqlx::SqlitePool;
+use time::Duration;
+use tower::ServiceExt;
+use tower_sessions::{cookie::Key, Expiry, SessionManagerLayer};
+use tower_sessions_sqlx_store::SqliteStore;
+
+use crate::{
+    users::{Backend, Credentials},
+    web::{auth, protected},
+};
+
+async fn setup_app(pool: SqlitePool) -> Result<Router, Box<dyn Error>> {
+    let session_store = SqliteStore::new(pool.clone());
+    session_store.migrate().await?;
+
+    // Generate a cryptographic key to sign the session cookie.
+    let key = Key::generate();
+
+    let session_layer = SessionManagerLayer::new(session_store)
+        .with_secure(false)
+        .with_expiry(Expiry::OnInactivity(Duration::days(1)))
+        .with_signed(key);
+    let backend = Backend::new(pool);
+    let auth_layer = AuthManagerLayerBuilder::new(backend, session_layer).build();
+    let app = protected::router()
+        .route_layer(login_required!(Backend, login_url = "/login"))
+        .merge(auth::router())
+        .layer(MessagesManagerLayer)
+        .layer(auth_layer);
+
+    Ok(app)
+}
+
+#[sqlx::test]
+async fn test_login_logout(pool: SqlitePool) {
+    let app = setup_app(pool).await.unwrap();
+
+    let login_request = {
+        let credentials = Credentials {
+            username: "ferris".to_string(),
+            password: "$argon2id$v=19$m=19456,t=2,\
+                       p=1$VE0e3g7DalWHgDwou3nuRA$uC6TER156UQpk0lNQ5+jHM0l5poVjPA1he/Tyn9J4Zw"
+                .to_string(),
+            next: None,
+        };
+        // todo: unclear how to instatiate or add to request; no tests in axum-messages
+        // let messages: Messages;
+        let credentials = serde_urlencoded::to_string(credentials).unwrap();
+
+        Request::builder()
+            .uri("/login")
+            .method("POST")
+            .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+            // todo: where do I put messages in the request?
+            .body(credentials)
+            .unwrap()
+    };
+    let login_response = app.clone().oneshot(login_request).await.unwrap();
+    dbg!(&login_response);
+    assert!(login_response.status().is_redirection());
+}

--- a/examples/sqlite/src/test.rs
+++ b/examples/sqlite/src/test.rs
@@ -1,8 +1,8 @@
 use std::error::Error;
 
-use axum::Router;
+use axum::{body::Body, Router};
 use axum_login::{login_required, AuthManagerLayerBuilder};
-use axum_messages::{Messages, MessagesManagerLayer};
+use axum_messages::MessagesManagerLayer;
 use http::{header::CONTENT_TYPE, Request};
 use sqlx::SqlitePool;
 use time::Duration;
@@ -64,4 +64,14 @@ async fn test_login_logout(pool: SqlitePool) {
     let login_response = app.clone().oneshot(login_request).await.unwrap();
     dbg!(&login_response);
     assert!(login_response.status().is_redirection());
+
+    // why is logout a get request instead of a post in the example?
+    let logout_request = Request::builder()
+        .uri("/logout")
+        .method("GET")
+        .body(Body::empty())
+        .unwrap();
+    let logout_response = app.clone().oneshot(logout_request).await.unwrap();
+    dbg!(&logout_response);
+    assert!(logout_response.status().is_redirection());
 }

--- a/examples/sqlite/src/test.rs
+++ b/examples/sqlite/src/test.rs
@@ -44,9 +44,7 @@ async fn test_login_logout(pool: SqlitePool) {
     let login_request = {
         let credentials = Credentials {
             username: "ferris".to_string(),
-            password: "$argon2id$v=19$m=19456,t=2,\
-                       p=1$VE0e3g7DalWHgDwou3nuRA$uC6TER156UQpk0lNQ5+jHM0l5poVjPA1he/Tyn9J4Zw"
-                .to_string(),
+            password: "hunter42".to_string(),
             next: None,
         };
         // todo: unclear how to instatiate or add to request; no tests in axum-messages
@@ -64,6 +62,8 @@ async fn test_login_logout(pool: SqlitePool) {
     let login_response = app.clone().oneshot(login_request).await.unwrap();
     dbg!(&login_response);
     assert!(login_response.status().is_redirection());
+
+    // todo: how to verify that the user is logged in?
 
     // why is logout a get request instead of a post in the example?
     let logout_request = Request::builder()

--- a/examples/sqlite/src/users.rs
+++ b/examples/sqlite/src/users.rs
@@ -41,7 +41,7 @@ impl AuthUser for User {
 
 // This allows us to extract the authentication fields from forms. We use this
 // to authenticate requests with the backend.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Credentials {
     pub username: String,
     pub password: String,

--- a/examples/sqlite/src/web.rs
+++ b/examples/sqlite/src/web.rs
@@ -1,5 +1,5 @@
 pub use app::App;
 
 mod app;
-mod auth;
-mod protected;
+pub(crate) mod auth;
+pub(crate) mod protected;


### PR DESCRIPTION
Adding a login-logout test to the sqlite example. 

Several questions arose while implementing the test:
- How to build the login request, to include cookies(*) like `AuthSession` and `Messages` in the request
- How to verify that the user is logged in
- Why logout is a `GET` request instead of a `POST` in these examples

these questions are documented in the test:
```rust
#[sqlx::test]
async fn test_login_logout(pool: SqlitePool) {
    let app = setup_app(pool).await.unwrap();

    let login_request = {
        let credentials = Credentials {
            username: "ferris".to_string(),
            password: "password".to_string(),
            next: None,
        };
        // todo: unclear how to instatiate or add to request; no tests in axum-messages
        // let messages: Messages;
        let credentials = serde_urlencoded::to_string(credentials).unwrap();

        Request::builder()
            .uri("/login")
            .method("POST")
            .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
            // todo: where do I put messages in the request?
            .body(credentials)
            .unwrap()
    };
    let login_response = app.clone().oneshot(login_request).await.unwrap();
    dbg!(&login_response);
    assert!(login_response.status().is_redirection());

    // todo: how to verify that the user is logged in?

    // why is logout a get request instead of a post in the example?
    let logout_request = Request::builder()
        .uri("/logout")
        .method("GET")
        .body(Body::empty())
        .unwrap();
    let logout_response = app.clone().oneshot(logout_request).await.unwrap();
    dbg!(&logout_response);
    assert!(logout_response.status().is_redirection());
}
```
