### PR TITLE
Replace Ring crate with Subtle

### DIFF
--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1.57"
 axum = { version = "0.7.1", default-features = false, features = [
     "original-uri",
 ] }
-ring = "0.17.5"
+subtle = "2.5.0"
 serde = "1"
 thiserror = "1.0.49"
 tower-cookies = "0.10.0"

--- a/axum-login/src/session.rs
+++ b/axum-login/src/session.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
-use subtle::ConstantTimeEq;
 use serde::{Deserialize, Serialize};
+use subtle::ConstantTimeEq;
 use tower_sessions::{session, Session};
 
 use crate::{
@@ -156,9 +156,10 @@ impl<Backend: AuthnBackend> AuthSession<Backend> {
 
         if let Some(ref authed_user) = user {
             let session_auth_hash = authed_user.session_auth_hash();
-            let session_verified = &data.auth_hash.clone().is_some_and(|auth_hash| {
-                auth_hash.ct_eq(session_auth_hash).into()
-            });
+            let session_verified = &data
+                .auth_hash
+                .clone()
+                .is_some_and(|auth_hash| auth_hash.ct_eq(session_auth_hash).into());
             if !session_verified {
                 user = None;
                 data = Data::default();

--- a/axum-login/src/session.rs
+++ b/axum-login/src/session.rs
@@ -157,7 +157,7 @@ impl<Backend: AuthnBackend> AuthSession<Backend> {
         if let Some(ref authed_user) = user {
             let session_auth_hash = authed_user.session_auth_hash();
             let session_verified = &data.auth_hash.clone().is_some_and(|auth_hash| {
-                auth_hash.ct_eq(&session_auth_hash).into()
+                auth_hash.ct_eq(session_auth_hash).into()
             });
             if !session_verified {
                 user = None;

--- a/axum-login/src/session.rs
+++ b/axum-login/src/session.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use ring::constant_time::verify_slices_are_equal;
+use subtle::ConstantTimeEq;
 use serde::{Deserialize, Serialize};
 use tower_sessions::{session, Session};
 
@@ -157,7 +157,7 @@ impl<Backend: AuthnBackend> AuthSession<Backend> {
         if let Some(ref authed_user) = user {
             let session_auth_hash = authed_user.session_auth_hash();
             let session_verified = &data.auth_hash.clone().is_some_and(|auth_hash| {
-                verify_slices_are_equal(&auth_hash[..], session_auth_hash).is_ok()
+                auth_hash.ct_eq(&session_auth_hash).into()
             });
             if !session_verified {
                 user = None;


### PR DESCRIPTION
Ring uses C and assembly code, which makes it more difficult to compile for targets like wasm32-unknown-unknown. Also in principle I believe using pure Rust should be preferred when possible in my opinion.

This is a very simple tweak based on the discussion in #122, [subtle](https://crates.io/crates/subtle) is the crate ultimately used by [password-auth](https://crates.io/crates/password-auth), via a dependency on [password-hash](https://crates.io/crates/password-hash).

This passes all tests that main previously did on my machine, see #215