### PR TITLE
Remove dotyenv dependency

### DIFF
--- a/examples/multi-auth/Cargo.toml
+++ b/examples/multi-auth/Cargo.toml
@@ -10,7 +10,6 @@ askama_axum = "0.4.0"
 async-trait = "0.1.74"
 axum = "0.7.1"
 axum-login = { path = "../../axum-login" }
-dotenvy = "0.15.7"
 http = "1.0.0"
 hyper = "1.0.1"
 oauth2 = "4.4.2"

--- a/examples/multi-auth/src/web/app.rs
+++ b/examples/multi-auth/src/web/app.rs
@@ -21,8 +21,6 @@ pub struct App {
 
 impl App {
     pub async fn new() -> Result<Self, Box<dyn std::error::Error>> {
-        dotenvy::dotenv()?;
-
         let client_id = env::var("CLIENT_ID")
             .map(ClientId::new)
             .expect("CLIENT_ID should be provided.");


### PR DESCRIPTION
Hi 👋 

thanks for this awesome crate! As a Rust newcomer I really appreciate the well structured examples. 
I acknowledge how hard it is to strike the balance between completeness and simplicity when building these 🙏 

I was not familiar with the dotyenv crate and as I copied the `multi_auth` example to run as a standalone `cargo run` bailed on me with `Error: Io(Custom { kind: NotFound, error: "path not found" })` with no indication where to look.

After some debugging I identified the missing `.env` file as the problem. However I also found removing `dotyenv` entirely doesn't seem to impact the functionality of the example.

That's why I'm proposing to remove it.