### PR TITLE
Change status code of "login_required" to 303

### DIFF
--- a/axum-login/src/middleware.rs
+++ b/axum-login/src/middleware.rs
@@ -179,7 +179,7 @@ macro_rules! predicate_required {
                         original_uri
                     ) {
                         Ok(login_url) => {
-                            Redirect::temporary(&login_url.to_string()).into_response()
+                            Redirect::to(&login_url.to_string()).into_response()
                         }
 
                         Err(err) => {
@@ -360,7 +360,7 @@ mod tests {
         let req = Request::builder().uri("/").body(Body::empty()).unwrap();
         let res = app.clone().oneshot(req).await.unwrap();
 
-        assert_eq!(res.status(), StatusCode::TEMPORARY_REDIRECT);
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
         assert_eq!(
             res.headers()
                 .get(header::LOCATION)
@@ -405,7 +405,7 @@ mod tests {
         let req = Request::builder().uri("/").body(Body::empty()).unwrap();
         let res = app.clone().oneshot(req).await.unwrap();
 
-        assert_eq!(res.status(), StatusCode::TEMPORARY_REDIRECT);
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
         assert_eq!(
             res.headers()
                 .get(header::LOCATION)
@@ -517,7 +517,7 @@ mod tests {
 
         let req = Request::builder().uri("/").body(Body::empty()).unwrap();
         let res = app.clone().oneshot(req).await.unwrap();
-        assert_eq!(res.status(), StatusCode::TEMPORARY_REDIRECT);
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
         assert_eq!(
             res.headers()
                 .get(header::LOCATION)
@@ -562,7 +562,7 @@ mod tests {
 
         let req = Request::builder().uri("/").body(Body::empty()).unwrap();
         let res = app.clone().oneshot(req).await.unwrap();
-        assert_eq!(res.status(), StatusCode::TEMPORARY_REDIRECT);
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
         assert_eq!(
             res.headers()
                 .get(header::LOCATION)
@@ -638,7 +638,7 @@ mod tests {
             .body(Body::empty())
             .unwrap();
         let res = app.oneshot(req).await.unwrap();
-        assert_eq!(res.status(), StatusCode::TEMPORARY_REDIRECT);
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
         assert_eq!(
             res.headers()
                 .get(header::LOCATION)
@@ -659,7 +659,7 @@ mod tests {
 
         let req = Request::builder().uri("/").body(Body::empty()).unwrap();
         let res = app.clone().oneshot(req).await.unwrap();
-        assert_eq!(res.status(), StatusCode::TEMPORARY_REDIRECT);
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
         assert_eq!(
             res.headers()
                 .get(header::LOCATION)
@@ -672,7 +672,7 @@ mod tests {
             .body(Body::empty())
             .unwrap();
         let res = app.oneshot(req).await.unwrap();
-        assert_eq!(res.status(), StatusCode::TEMPORARY_REDIRECT);
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
         assert_eq!(
             res.headers()
                 .get(header::LOCATION)
@@ -694,7 +694,7 @@ mod tests {
 
         let req = Request::builder().uri("/").body(Body::empty()).unwrap();
         let res = app.oneshot(req).await.unwrap();
-        assert_eq!(res.status(), StatusCode::TEMPORARY_REDIRECT);
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
         assert_eq!(
             res.headers()
                 .get(header::LOCATION)
@@ -712,7 +712,7 @@ mod tests {
 
         let req = Request::builder().uri("/").body(Body::empty()).unwrap();
         let res = app.oneshot(req).await.unwrap();
-        assert_eq!(res.status(), StatusCode::TEMPORARY_REDIRECT);
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
         assert_eq!(
             res.headers()
                 .get(header::LOCATION)
@@ -733,7 +733,7 @@ mod tests {
             .body(Body::empty())
             .unwrap();
         let res = app.oneshot(req).await.unwrap();
-        assert_eq!(res.status(), StatusCode::TEMPORARY_REDIRECT);
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
         assert_eq!(
             res.headers()
                 .get(header::LOCATION)


### PR DESCRIPTION
This change modifies the status code used in the `login_required!` from its current value of 307 (Temporary Redirect) to 303 (See Other). The update improves the redirect behavior when authentication fails.

Reasons:

- The current 307 (Temporary Redirect) status code maintains the original request method during redirection.
- Changing to a 303 (See Other) status code forces the redirect to use a GET request, regardless of the original request method.
- Previously, if authentication failed during a non-GET request (like POST), the redirect would use the same method as the original request. For example, a failed auth during a POST request would redirect to POST /login (with all the form data from the original request) instead of GET /login.
- This change ensures that all redirects to the login page will use GET, which is the correct behavior for displaying a login form.

For more information on these status codes, see:

[MDN Web Docs - 303 See Other](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303)
[MDN Web Docs - 307 Temporary Redirect](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307)
