### PR TITLE
Added method has_all_perm to improve db calls when checking for multiple permissions

### DIFF
--- a/axum-login/src/middleware.rs
+++ b/axum-login/src/middleware.rs
@@ -81,12 +81,7 @@ macro_rules! permission_required {
 
         async fn is_authorized(auth_session: $crate::AuthSession<$backend_type>) -> bool {
             if let Some(ref user) = auth_session.user {
-                let mut has_all_permissions = true;
-                $(
-                    has_all_permissions = has_all_permissions &&
-                        auth_session.backend.has_perm(user, $perm.into()).await.unwrap_or(false);
-                )+
-                has_all_permissions
+                auth_session.backend.has_all_perm(user, vec![$($perm.into(),)+]).await.unwrap_or(false)
             } else {
                 false
             }
@@ -113,12 +108,7 @@ macro_rules! permission_required {
 
         async fn is_authorized(auth_session: $crate::AuthSession<$backend_type>) -> bool {
             if let Some(ref user) = auth_session.user {
-                let mut has_all_permissions = true;
-                $(
-                    has_all_permissions = has_all_permissions &&
-                        auth_session.backend.has_perm(user, $perm.into()).await.unwrap_or(false);
-                )+
-                has_all_permissions
+                auth_session.backend.has_all_perm(user, vec![$($perm.into(),)+]).await.unwrap_or(false)
             } else {
                 false
             }


### PR DESCRIPTION
When checking for multiple permissions every check was making a db call, this change improves that a bit.
If it was like that for a reason then just ignore this PR.