### PR TITLE
make Session public

### DIFF
--- a/axum-login/src/session.rs
+++ b/axum-login/src/session.rs
@@ -79,7 +79,7 @@ pub struct AuthSession<Backend: AuthnBackend> {
     /// The authentication and authorization backend.
     pub backend: Backend,
 
-    /// The underyling session.
+    /// The underlying session.
     pub session: Session,
 
     data: Data<UserId<Backend>>,

--- a/axum-login/src/session.rs
+++ b/axum-login/src/session.rs
@@ -79,8 +79,10 @@ pub struct AuthSession<Backend: AuthnBackend> {
     /// The authentication and authorization backend.
     pub backend: Backend,
 
+    /// The underyling session.
+    pub session: Session,
+
     data: Data<UserId<Backend>>,
-    session: Session,
     data_key: &'static str,
 }
 


### PR DESCRIPTION
I have a case wherein I'd like to do something with the `Session` and I already have the `AuthSession` available. I could extract it separately, but I'm not sure why this field can't be `pub`.