### PR TITLE
fix integration tests

### DIFF
--- a/axum-login/tests/integration-test.rs
+++ b/axum-login/tests/integration-test.rs
@@ -1,13 +1,142 @@
 use std::{
     collections::HashMap,
     process::{Child, Command},
+    sync::Arc,
     time::{Duration, Instant},
 };
 
-use reqwest::Client;
+use reqwest::{
+    cookie::{CookieStore, Jar},
+    Client, StatusCode, Url,
+};
 use serial_test::serial;
 
 const WEBSERVER_URL: &str = "http://localhost:3000";
+
+#[tokio::test]
+#[serial]
+async fn sqlite_example() {
+    let _child_guard = start_example_binary("example-sqlite").await;
+
+    let cookie_jar = Arc::new(Jar::default());
+    let client = Client::builder()
+        .cookie_provider(cookie_jar.clone())
+        .build()
+        .unwrap();
+
+    // A logged out user is redirected to the login URL with a next query
+    //string.
+    let res = client.get(url("/")).send().await.unwrap();
+    assert_eq!(*res.url(), url("/login?next=%2F"));
+    assert_eq!(res.status(), StatusCode::OK);
+
+    assert!(
+        cookie_jar.cookies(&url("/")).is_none(),
+        "Expected 'id' cookie to not be set after failed login"
+    );
+
+    // Log in with invalid credentials.
+    let res = login(&client, "ferris", "bogus").await;
+    assert_eq!(*res.url(), url("/login"));
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let cookies = cookie_jar
+        .cookies(&url("/"))
+        .expect("A cookie should be set");
+    assert!(
+        cookies.to_str().unwrap_or("").contains("id="),
+        "Expected 'id' cookie to be set after login"
+    );
+
+    // Log in with valid credentials.
+    let res = login(&client, "ferris", "hunter42").await;
+    assert_eq!(*res.url(), url("/"));
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // Log out and check the cookie has been removed in response.
+    let res = client.get(url("/logout")).send().await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(
+        cookie_jar.cookies(&url("/")).iter().len(),
+        0,
+        "Expected 'id' cookie to be removed"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn permissions_example() {
+    let _child_guard = start_example_binary("example-permissions").await;
+
+    let cookie_jar = Arc::new(Jar::default());
+    let client = Client::builder()
+        .cookie_provider(cookie_jar.clone())
+        .build()
+        .unwrap();
+
+    // A logged out user is redirected to the login URL with a next query string.
+    let res = client.get(url("/")).send().await.unwrap();
+
+    assert_eq!(*res.url(), url("/login?next=%2F"));
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // Log in with invalid credentials.
+    let res = login(&client, "ferris", "bogus").await;
+
+    assert_eq!(*res.url(), url("/login"));
+    assert_eq!(res.status(), StatusCode::OK);
+
+    assert!(
+        cookie_jar.cookies(&url("/")).is_none(),
+        "Expected 'id' cookie to not be set after failed login"
+    );
+
+    // Log in with valid credentials.
+    let res = login(&client, "ferris", "hunter42").await;
+
+    assert_eq!(*res.url(), url("/"));
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let cookies = cookie_jar
+        .cookies(&url("/"))
+        .expect("A cookie should be set");
+    assert!(
+        cookies.to_str().unwrap_or("").contains("id="),
+        "Expected 'id' cookie to be set after login"
+    );
+
+    // Try to access restricted page.
+    let res = client.get(url("/restricted")).send().await.unwrap();
+    assert_eq!(*res.url(), url("/login?next=%2Frestricted"));
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // Log in with valid credentials.
+    let res = login(&client, "admin", "hunter42").await;
+
+    assert_eq!(*res.url(), url("/"));
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let cookies = cookie_jar.cookies(&url("/")).unwrap();
+    assert!(
+        cookies.to_str().unwrap_or("").contains("id="),
+        "Expected 'id' cookie to be set after login"
+    );
+
+    // Now we should be able to access the restricted page.
+    let res = client.get(url("/restricted")).send().await.unwrap();
+    assert_eq!(*res.url(), url("/restricted"));
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // Log out and check the cookie has been removed in response.
+    let res = client.get(url("/logout")).send().await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    assert_eq!(
+        cookie_jar.cookies(&url("/")).iter().len(),
+        0,
+        "Expected 'id' cookie to be removed"
+    );
+}
 
 struct ChildGuard {
     child: Child,
@@ -48,133 +177,18 @@ async fn start_example_binary(binary_name: &str) -> ChildGuard {
     ChildGuard { child }
 }
 
-#[tokio::test]
-#[serial]
-async fn sqlite_example() {
-    let _child_guard = start_example_binary("example-sqlite").await;
-
-    let client = Client::builder().cookie_store(true).build().unwrap();
-
-    // A logged out user is redirected to the login URL with a next query string.
-    let res = client.get(WEBSERVER_URL).send().await.unwrap();
-    assert_eq!(
-        res.url().to_string(),
-        format!("{WEBSERVER_URL}/login?next=%2F")
-    );
-
-    // Log in with invalid credentials.
-    let mut form = HashMap::new();
-    form.insert("username", "ferris");
-    form.insert("password", "bogus");
-    let res = client
-        .post(format!("{WEBSERVER_URL}/login"))
-        .form(&form)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(res.url().to_string(), format!("{WEBSERVER_URL}/login"));
-
-    // Log in with valid credentials.
-    let mut form = HashMap::new();
-    form.insert("username", "ferris");
-    form.insert("password", "hunter42");
-    let res = client
-        .post(format!("{WEBSERVER_URL}/login"))
-        .form(&form)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(res.url().to_string(), format!("{WEBSERVER_URL}/"));
-
-    // Log out and check the cookie has been removed in response.
-    let res = client
-        .get(format!("{WEBSERVER_URL}/logout"))
-        .send()
-        .await
-        .unwrap();
-    assert!(res
-        .cookies()
-        .find(|c| c.name() == "id")
-        .is_some_and(|c| c.value() == ""));
+fn url(path: &str) -> Url {
+    let formatted_url = if path.starts_with('/') {
+        format!("{WEBSERVER_URL}{path}")
+    } else {
+        format!("{WEBSERVER_URL}/{path}")
+    };
+    formatted_url.parse().unwrap()
 }
 
-#[tokio::test]
-#[serial]
-async fn permissions_example() {
-    let _child_guard = start_example_binary("example-permissions").await;
-
-    let client = Client::builder().cookie_store(true).build().unwrap();
-
-    // A logged out user is redirected to the login URL with a next query string.
-    let res = client.get(WEBSERVER_URL).send().await.unwrap();
-    assert_eq!(
-        res.url().to_string(),
-        format!("{WEBSERVER_URL}/login?next=%2F")
-    );
-
-    // Log in with invalid credentials.
+async fn login(client: &Client, username: &str, password: &str) -> reqwest::Response {
     let mut form = HashMap::new();
-    form.insert("username", "ferris");
-    form.insert("password", "bogus");
-    let res = client
-        .post(format!("{WEBSERVER_URL}/login"))
-        .form(&form)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(res.url().to_string(), format!("{WEBSERVER_URL}/login"));
-
-    // Log in with valid credentials.
-    let mut form = HashMap::new();
-    form.insert("username", "ferris");
-    form.insert("password", "hunter42");
-    let res = client
-        .post(format!("{WEBSERVER_URL}/login"))
-        .form(&form)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(res.url().to_string(), format!("{WEBSERVER_URL}/"));
-
-    // Try to access restricted page.
-    let res = client
-        .get(format!("{WEBSERVER_URL}/restricted"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(
-        res.url().to_string(),
-        format!("{WEBSERVER_URL}/login?next=%2Frestricted")
-    );
-
-    // Log in with valid credentials.
-    let mut form = HashMap::new();
-    form.insert("username", "admin");
-    form.insert("password", "hunter42");
-    let res = client
-        .post(format!("{WEBSERVER_URL}/login"))
-        .form(&form)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(res.url().to_string(), format!("{WEBSERVER_URL}/"));
-
-    // Now we should be able to access the restricted page.
-    let res = client
-        .get(format!("{WEBSERVER_URL}/restricted"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(res.url().to_string(), format!("{WEBSERVER_URL}/restricted"));
-
-    // Log out and check the cookie has been removed in response.
-    let res = client
-        .get(format!("{WEBSERVER_URL}/logout"))
-        .send()
-        .await
-        .unwrap();
-    assert!(res
-        .cookies()
-        .find(|c| c.name() == "id")
-        .is_some_and(|c| c.value() == ""));
+    form.insert("username", username);
+    form.insert("password", password);
+    client.post(url("/login")).form(&form).send().await.unwrap()
 }


### PR DESCRIPTION
For one reason or another, the ability to rely on the set-cookie header to introspect cookies via reqwest seems to no longer work with Github Actions; this otherwise works in a local environment so the reason is not immediately clear.

That said this can be worked around by using a cookie jar directly and observing the changes the client is making therein. This fix is applied here.

At the same time a few minor clean ups are provided.