### PR TITLE
refactor(session): ensure thread-safe state

### DIFF
--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -27,6 +27,7 @@ tower-cookies = "0.11.0"
 tower-layer = "0.3.2"
 tower-service = "0.3.2"
 tower-sessions = { version = "0.14.0", default-features = false }
+tokio = { version = "1.46.1", default-features = false, features = ["sync"] }
 tracing = { version = "0.1.40", features = ["log"] }
 urlencoding = "2.1.3"
 form_urlencoded = "1.2.1"

--- a/axum-login/src/middleware.rs
+++ b/axum-login/src/middleware.rs
@@ -40,7 +40,7 @@ pub fn url_with_redirect_query(
 macro_rules! login_required {
     ($backend_type:ty) => {{
         async fn is_authenticated(auth_session: $crate::AuthSession<$backend_type>) -> bool {
-            auth_session.user.is_some()
+            auth_session.user().await.is_some()
         }
 
         $crate::predicate_required!(
@@ -51,7 +51,7 @@ macro_rules! login_required {
 
     ($backend_type:ty, login_url = $login_url:expr, redirect_field = $redirect_field:expr) => {{
         async fn is_authenticated(auth_session: $crate::AuthSession<$backend_type>) -> bool {
-            auth_session.user.is_some()
+            auth_session.user().await.is_some()
         }
 
         $crate::predicate_required!(
@@ -80,11 +80,11 @@ macro_rules! permission_required {
         use $crate::AuthzBackend;
 
         async fn is_authorized(auth_session: $crate::AuthSession<$backend_type>) -> bool {
-            if let Some(ref user) = auth_session.user {
+            if let Some(ref user) = auth_session.user().await {
                 let mut has_all_permissions = true;
                 $(
                     has_all_permissions = has_all_permissions &&
-                        auth_session.backend.has_perm(user, $perm.into()).await.unwrap_or(false);
+                        auth_session.backend().has_perm(user, $perm.into()).await.unwrap_or(false);
                 )+
                 has_all_permissions
             } else {
@@ -112,11 +112,11 @@ macro_rules! permission_required {
         use $crate::AuthzBackend;
 
         async fn is_authorized(auth_session: $crate::AuthSession<$backend_type>) -> bool {
-            if let Some(ref user) = auth_session.user {
+            if let Some(ref user) = auth_session.user().await {
                 let mut has_all_permissions = true;
                 $(
                     has_all_permissions = has_all_permissions &&
-                        auth_session.backend.has_perm(user, $perm.into()).await.unwrap_or(false);
+                        auth_session.backend().has_perm(user, $perm.into()).await.unwrap_or(false);
                 )+
                 has_all_permissions
             } else {

--- a/axum-login/src/service.rs
+++ b/axum-login/src/service.rs
@@ -89,7 +89,7 @@ where
                     }
                 };
 
-                if let Some(ref user) = auth_session.user {
+                if let Some(ref user) = auth_session.user().await {
                     tracing::Span::current().record("user.id", user.id().to_string());
                 }
 

--- a/examples/multi-auth/src/web/auth.rs
+++ b/examples/multi-auth/src/web/auth.rs
@@ -81,7 +81,7 @@ mod post {
             session: Session,
             Form(NextUrl { next }): Form<NextUrl>,
         ) -> impl IntoResponse {
-            let (auth_url, csrf_state) = auth_session.backend.authorize_url();
+            let (auth_url, csrf_state) = auth_session.backend().authorize_url();
 
             session
                 .insert(CSRF_STATE_KEY, csrf_state.secret())

--- a/examples/multi-auth/src/web/protected.rs
+++ b/examples/multi-auth/src/web/protected.rs
@@ -22,7 +22,7 @@ mod get {
     use super::*;
 
     pub async fn protected(auth_session: AuthSession) -> impl IntoResponse {
-        match auth_session.user {
+        match auth_session.user().await {
             Some(user) => Html(
                 ProtectedTemplate {
                     username: &user.username,

--- a/examples/oauth2/src/web/auth.rs
+++ b/examples/oauth2/src/web/auth.rs
@@ -42,7 +42,7 @@ mod post {
         session: Session,
         Form(NextUrl { next }): Form<NextUrl>,
     ) -> impl IntoResponse {
-        let (auth_url, csrf_state) = auth_session.backend.authorize_url();
+        let (auth_url, csrf_state) = auth_session.backend().authorize_url();
 
         session
             .insert(CSRF_STATE_KEY, csrf_state.secret())

--- a/examples/oauth2/src/web/protected.rs
+++ b/examples/oauth2/src/web/protected.rs
@@ -22,7 +22,7 @@ mod get {
     use super::*;
 
     pub async fn protected(auth_session: AuthSession) -> impl IntoResponse {
-        match auth_session.user {
+        match auth_session.user().await {
             Some(user) => Html(
                 ProtectedTemplate {
                     username: &user.username,

--- a/examples/permissions/src/web/protected.rs
+++ b/examples/permissions/src/web/protected.rs
@@ -19,7 +19,7 @@ mod get {
     use super::*;
 
     pub async fn protected(auth_session: AuthSession) -> impl IntoResponse {
-        match auth_session.user {
+        match auth_session.user().await {
             Some(user) => Html(
                 ProtectedTemplate {
                     username: &user.username,

--- a/examples/permissions/src/web/restricted.rs
+++ b/examples/permissions/src/web/restricted.rs
@@ -14,15 +14,19 @@ pub fn router() -> Router<()> {
 }
 
 mod get {
+    use axum::response::Html;
+
     use super::*;
 
     pub async fn restricted(auth_session: AuthSession) -> impl IntoResponse {
-        match auth_session.user {
-            Some(user) => RestrictedTemplate {
-                username: &user.username,
-            }
-            .render()
-            .unwrap()
+        match auth_session.user().await {
+            Some(user) => Html(
+                RestrictedTemplate {
+                    username: &user.username,
+                }
+                .render()
+                .unwrap(),
+            )
             .into_response(),
 
             None => StatusCode::INTERNAL_SERVER_ERROR.into_response(),

--- a/examples/sqlite/src/web/protected.rs
+++ b/examples/sqlite/src/web/protected.rs
@@ -24,7 +24,7 @@ mod get {
     use super::*;
 
     pub async fn protected(auth_session: AuthSession, messages: Messages) -> impl IntoResponse {
-        match auth_session.user {
+        match auth_session.user().await {
             Some(user) => Html(
                 ProtectedTemplate {
                     messages: messages.into_iter().collect(),


### PR DESCRIPTION
Originally the auth session was not designed to be shared between middleware. However, in practice it's convenient and indeed idiomatic to share auth between middleware before a request has been fully resolved. This allows e.g. specialized handling of auth semantics, such that applications may leverage the session indirectly.

To do so, the entire state of the auth session must be reworked to support interior mutability. This allows the session state to be passed between and manipulated by intermediary middleware. The downside to this approach is that locking is required given the fundamental nature of middleware. But the benefit is that now state is visible where it otherwise was not.

This also introduces several breaking changes:

1. Users are now accessible via the `user` method, which must be awaited.
2. The backend is no longer an attribute and instead must be accessed through the `backend` method.
3. Access to the session has been removed since this requires a clone; instead the `Session` should simply be used directly.

The examples and tests have been updated to reflect these changes.