### PR TITLE
Update examples to match latest axum-login

### DIFF
--- a/examples/multi-auth/src/web/auth.rs
+++ b/examples/multi-auth/src/web/auth.rs
@@ -81,7 +81,7 @@ mod post {
             session: Session,
             Form(NextUrl { next }): Form<NextUrl>,
         ) -> impl IntoResponse {
-            let (auth_url, csrf_state) = auth_session.backend().authorize_url();
+            let (auth_url, csrf_state) = auth_session.backend.authorize_url();
 
             session
                 .insert(CSRF_STATE_KEY, csrf_state.secret())

--- a/examples/multi-auth/src/web/protected.rs
+++ b/examples/multi-auth/src/web/protected.rs
@@ -22,7 +22,7 @@ mod get {
     use super::*;
 
     pub async fn protected(auth_session: AuthSession) -> impl IntoResponse {
-        match auth_session.user().await {
+        match auth_session.user {
             Some(user) => Html(
                 ProtectedTemplate {
                     username: &user.username,

--- a/examples/oauth2/src/web/auth.rs
+++ b/examples/oauth2/src/web/auth.rs
@@ -42,7 +42,7 @@ mod post {
         session: Session,
         Form(NextUrl { next }): Form<NextUrl>,
     ) -> impl IntoResponse {
-        let (auth_url, csrf_state) = auth_session.backend().authorize_url();
+        let (auth_url, csrf_state) = auth_session.backend.authorize_url();
 
         session
             .insert(CSRF_STATE_KEY, csrf_state.secret())

--- a/examples/oauth2/src/web/protected.rs
+++ b/examples/oauth2/src/web/protected.rs
@@ -22,7 +22,7 @@ mod get {
     use super::*;
 
     pub async fn protected(auth_session: AuthSession) -> impl IntoResponse {
-        match auth_session.user().await {
+        match auth_session.user {
             Some(user) => Html(
                 ProtectedTemplate {
                     username: &user.username,

--- a/examples/permissions/src/web/protected.rs
+++ b/examples/permissions/src/web/protected.rs
@@ -19,7 +19,7 @@ mod get {
     use super::*;
 
     pub async fn protected(auth_session: AuthSession) -> impl IntoResponse {
-        match auth_session.user().await {
+        match auth_session.user {
             Some(user) => Html(
                 ProtectedTemplate {
                     username: &user.username,

--- a/examples/permissions/src/web/restricted.rs
+++ b/examples/permissions/src/web/restricted.rs
@@ -19,7 +19,7 @@ mod get {
     use super::*;
 
     pub async fn restricted(auth_session: AuthSession) -> impl IntoResponse {
-        match auth_session.user().await {
+        match auth_session.user {
             Some(user) => Html(
                 RestrictedTemplate {
                     username: &user.username,

--- a/examples/sqlite/src/web/protected.rs
+++ b/examples/sqlite/src/web/protected.rs
@@ -24,7 +24,7 @@ mod get {
     use super::*;
 
     pub async fn protected(auth_session: AuthSession, messages: Messages) -> impl IntoResponse {
-        match auth_session.user().await {
+        match auth_session.user {
             Some(user) => Html(
                 ProtectedTemplate {
                     messages: messages.into_iter().collect(),


### PR DESCRIPTION
Changes include:

- Replacing method calls with direct field access (auth_session.user and auth_session.backend)
- Removing unnecessary .await from user access
- Ensuring examples compile and run with axum-login 0.18

This aligns the code with the current axum-login API and resolves compilation errors for users on the latest version.