### PR TITLE
add logout link to permissions and sqlite examples

### DIFF
--- a/examples/permissions/templates/protected.html
+++ b/examples/permissions/templates/protected.html
@@ -8,5 +8,6 @@
       Logged in as {{username}}, who has the
       <code>"protected.read"</code> permission.
     </p>
+    <a href="/logout">Logout</a>
   </body>
 </html>

--- a/examples/permissions/templates/restricted.html
+++ b/examples/permissions/templates/restricted.html
@@ -8,5 +8,6 @@
       Logged in as {{username}}, who has the
       <code>"restricted.read"</code> permission.
     </p>
+    <a href="/logout">Logout</a>
   </body>
 </html>

--- a/examples/sqlite/templates/protected.html
+++ b/examples/sqlite/templates/protected.html
@@ -13,5 +13,7 @@
     </ul>
 
     <p>Logged in as {{username}}</p>
+
+    <a href="/logout">Logout</a>
   </body>
 </html>


### PR DESCRIPTION
Having a way to logout in the examples is nice during testing. I have left out the oauth2 and multi-auth examples as it is too much trouble to run them.