### PR TITLE
remove `mut` in AuthSession::{logout, login}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Remove `mut` in AuthSession::{logout, login}. #300
+
 # 0.18.0
 
 - Disable default features for `tower-sessions`. #287

--- a/axum-login/src/middleware.rs
+++ b/axum-login/src/middleware.rs
@@ -314,7 +314,7 @@ mod tests {
             .route_layer(login_required!(Backend))
             .route(
                 "/login",
-                axum::routing::get(|mut auth_session: AuthSession<Backend>| async move {
+                axum::routing::get(|auth_session: AuthSession<Backend>| async move {
                     auth_session.login(&User).await.unwrap();
                 }),
             )
@@ -348,7 +348,7 @@ mod tests {
             .route_layer(login_required!(Backend, login_url = "/login"))
             .route(
                 "/login",
-                axum::routing::get(|mut auth_session: AuthSession<Backend>| async move {
+                axum::routing::get(|auth_session: AuthSession<Backend>| async move {
                     auth_session.login(&User).await.unwrap();
                 }),
             )
@@ -393,7 +393,7 @@ mod tests {
             ))
             .route(
                 "/signin",
-                axum::routing::get(|mut auth_session: AuthSession<Backend>| async move {
+                axum::routing::get(|auth_session: AuthSession<Backend>| async move {
                     auth_session.login(&User).await.unwrap();
                 }),
             )
@@ -434,7 +434,7 @@ mod tests {
             .route_layer(permission_required!(Backend, "test.read"))
             .route(
                 "/login",
-                axum::routing::get(|mut auth_session: AuthSession<Backend>| async move {
+                axum::routing::get(|auth_session: AuthSession<Backend>| async move {
                     auth_session.login(&User).await.unwrap();
                 }),
             )
@@ -468,7 +468,7 @@ mod tests {
             .route_layer(permission_required!(Backend, "test.read", "test.write"))
             .route(
                 "/login",
-                axum::routing::get(|mut auth_session: AuthSession<Backend>| async move {
+                axum::routing::get(|auth_session: AuthSession<Backend>| async move {
                     auth_session.login(&User).await.unwrap();
                 }),
             )
@@ -506,7 +506,7 @@ mod tests {
             ))
             .route(
                 "/login",
-                axum::routing::get(|mut auth_session: AuthSession<Backend>| async move {
+                axum::routing::get(|auth_session: AuthSession<Backend>| async move {
                     auth_session.login(&User).await.unwrap();
                 }),
             )
@@ -551,7 +551,7 @@ mod tests {
             ))
             .route(
                 "/signin",
-                axum::routing::get(|mut auth_session: AuthSession<Backend>| async move {
+                axum::routing::get(|auth_session: AuthSession<Backend>| async move {
                     auth_session.login(&User).await.unwrap();
                 }),
             )
@@ -596,7 +596,7 @@ mod tests {
             ))
             .route(
                 "/login",
-                axum::routing::get(|mut auth_session: AuthSession<Backend>| async move {
+                axum::routing::get(|auth_session: AuthSession<Backend>| async move {
                     auth_session.login(&User).await.unwrap();
                 }),
             )

--- a/axum-login/src/session.rs
+++ b/axum-login/src/session.rs
@@ -119,7 +119,7 @@ impl<Backend: AuthnBackend> AuthSession<Backend> {
 
     /// Updates the session such that the user is logged in.
     #[tracing::instrument(level = "debug", skip_all, fields(user.id = user.id().to_string()), ret, err)]
-    pub async fn login(&mut self, user: &Backend::User) -> Result<(), Error<Backend>> {
+    pub async fn login(&self, user: &Backend::User) -> Result<(), Error<Backend>> {
         {
             let mut inner = self.inner.lock().await;
             inner.user = Some(user.clone());
@@ -139,7 +139,7 @@ impl<Backend: AuthnBackend> AuthSession<Backend> {
 
     /// Updates the session such that the user is logged out.
     #[tracing::instrument(level = "debug", skip_all, fields(user.id), ret, err)]
-    pub async fn logout(&mut self) -> Result<Option<Backend::User>, Error<Backend>> {
+    pub async fn logout(&self) -> Result<Option<Backend::User>, Error<Backend>> {
         let mut inner = self.inner.lock().await;
         let user = inner.user.take();
 
@@ -152,7 +152,7 @@ impl<Backend: AuthnBackend> AuthSession<Backend> {
         Ok(user)
     }
 
-    async fn update_session(&mut self) -> Result<(), session::Error> {
+    async fn update_session(&self) -> Result<(), session::Error> {
         let inner = self.inner.lock().await;
         inner
             .session
@@ -337,7 +337,7 @@ mod tests {
             data: Data::default(),
             data_key: "auth_data",
         };
-        let mut auth_session = AuthSession {
+        let auth_session = AuthSession {
             backend: mock_backend,
             inner: Arc::new(Mutex::new(inner)),
         };
@@ -372,7 +372,7 @@ mod tests {
             data: Data::default(),
             data_key: "auth_data",
         };
-        let mut auth_session = AuthSession {
+        let auth_session = AuthSession {
             backend: mock_backend,
             inner: Arc::new(Mutex::new(inner)),
         };

--- a/examples/multi-auth/src/web/auth.rs
+++ b/examples/multi-auth/src/web/auth.rs
@@ -43,7 +43,7 @@ mod post {
         use crate::users::{Credentials, PasswordCreds};
 
         pub async fn password(
-            mut auth_session: AuthSession,
+            auth_session: AuthSession,
             Form(creds): Form<PasswordCreds>,
         ) -> impl IntoResponse {
             let user = match auth_session
@@ -112,7 +112,7 @@ mod get {
         )
     }
 
-    pub async fn logout(mut auth_session: AuthSession) -> impl IntoResponse {
+    pub async fn logout(auth_session: AuthSession) -> impl IntoResponse {
         match auth_session.logout().await {
             Ok(_) => Redirect::to("/login").into_response(),
             Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),

--- a/examples/multi-auth/src/web/oauth.rs
+++ b/examples/multi-auth/src/web/oauth.rs
@@ -32,7 +32,7 @@ mod get {
     use crate::users::OAuthCreds;
 
     pub async fn callback(
-        mut auth_session: AuthSession,
+        auth_session: AuthSession,
         session: Session,
         Query(AuthzResp {
             code,

--- a/examples/oauth2/src/web/auth.rs
+++ b/examples/oauth2/src/web/auth.rs
@@ -72,7 +72,7 @@ mod get {
         )
     }
 
-    pub async fn logout(mut auth_session: AuthSession) -> impl IntoResponse {
+    pub async fn logout(auth_session: AuthSession) -> impl IntoResponse {
         match auth_session.logout().await {
             Ok(_) => Redirect::to("/login").into_response(),
             Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),

--- a/examples/oauth2/src/web/oauth.rs
+++ b/examples/oauth2/src/web/oauth.rs
@@ -31,7 +31,7 @@ mod get {
     use super::*;
 
     pub async fn callback(
-        mut auth_session: AuthSession,
+        auth_session: AuthSession,
         session: Session,
         Query(AuthzResp {
             code,

--- a/examples/permissions/src/web/auth.rs
+++ b/examples/permissions/src/web/auth.rs
@@ -35,7 +35,7 @@ mod post {
     use super::*;
 
     pub async fn login(
-        mut auth_session: AuthSession,
+        auth_session: AuthSession,
         Form(creds): Form<Credentials>,
     ) -> impl IntoResponse {
         let user = match auth_session.authenticate(creds.clone()).await {
@@ -80,7 +80,7 @@ mod get {
         )
     }
 
-    pub async fn logout(mut auth_session: AuthSession) -> impl IntoResponse {
+    pub async fn logout(auth_session: AuthSession) -> impl IntoResponse {
         match auth_session.logout().await {
             Ok(_) => Redirect::to("/login").into_response(),
             Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),

--- a/examples/sqlite/src/web/auth.rs
+++ b/examples/sqlite/src/web/auth.rs
@@ -36,7 +36,7 @@ mod post {
     use super::*;
 
     pub async fn login(
-        mut auth_session: AuthSession,
+        auth_session: AuthSession,
         messages: Messages,
         Form(creds): Form<Credentials>,
     ) -> impl IntoResponse {
@@ -87,7 +87,7 @@ mod get {
         )
     }
 
-    pub async fn logout(mut auth_session: AuthSession) -> impl IntoResponse {
+    pub async fn logout(auth_session: AuthSession) -> impl IntoResponse {
         match auth_session.logout().await {
             Ok(_) => Redirect::to("/login").into_response(),
             Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),


### PR DESCRIPTION
With https://github.com/maxcountryman/axum-login/commit/375856753e0fa7480f3e07013488c9fe678c2f65, it is much easier to use axum-login in multi-threads.

However, login and logout are still requiring `mut` which I believe it is not necessary because `Session` is already interiorly mutable.

Use Case with async-graphql:
```rs
#[Object]
impl Query {
    async fn borrow_from_context_data<'ctx>(
        &self,
        ctx: &Context<'ctx>
    ) -> Result<&'ctx String> {
        // `session` is not mutable
        // data only returns a ref https://docs.rs/async-graphql/latest/async_graphql/context/trait.DataContext.html#tymethod.data
        let session = ctx.data::<AuthSession>()?;
        // failed because it is not `mut`
        session.logout();
    }
}
```


