### PR TITLE
Upgrade tower-sessions to 0.15.0

### DIFF
--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -48,7 +48,7 @@ time = "0.3.36"
 tokio = { version = "1.32.0", features = ["full"] }
 tokio-test = "0.4.3"
 tower = "0.5.2"
-tower-sessions = { version = "0.14.0", features = ["memory-store"] }
+tower-sessions = { version = "0.15.0", features = ["memory-store"] }
 tower-sessions-sqlx-store = { version = "0.15.0", features = ["sqlite"] }
 
 [[bench]]

--- a/axum-login/Cargo.toml
+++ b/axum-login/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = "2.0.0"
 tower-cookies = "0.11.0"
 tower-layer = "0.3.2"
 tower-service = "0.3.2"
-tower-sessions = { version = "0.14.0", default-features = false }
+tower-sessions = { version = "0.15.0", default-features = false }
 tokio = { version = "1.46.1", default-features = false, features = ["sync"] }
 tracing = { version = "0.1.40", features = ["log"] }
 urlencoding = "2.1.3"

--- a/examples/multi-auth/Cargo.toml
+++ b/examples/multi-auth/Cargo.toml
@@ -21,4 +21,4 @@ tokio = { version = "1.34.0", features = ["full"] }
 tower = "0.5.2"
 password-auth = "1.0.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-tower-sessions = { version = "0.14.0", features = ["memory-store"] }
+tower-sessions = { version = "0.15.0", features = ["memory-store"] }

--- a/examples/oauth2/Cargo.toml
+++ b/examples/oauth2/Cargo.toml
@@ -20,4 +20,4 @@ time = "0.3.30"
 tokio = { version = "1.34.0", features = ["full"] }
 tower = "0.5.2"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-tower-sessions = { version = "0.14.0", features = ["memory-store"] }
+tower-sessions = { version = "0.15.0", features = ["memory-store"] }

--- a/examples/permissions/Cargo.toml
+++ b/examples/permissions/Cargo.toml
@@ -18,4 +18,4 @@ time = "0.3.30"
 tokio = { version = "1.34.0", features = ["full"] }
 tower = "0.5.2"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-tower-sessions = { version = "0.14.0", features = ["memory-store"] }
+tower-sessions = { version = "0.15.0", features = ["memory-store"] }

--- a/examples/sqlite/Cargo.toml
+++ b/examples/sqlite/Cargo.toml
@@ -18,7 +18,7 @@ time = "0.3.30"
 tokio = { version = "1.34.0", features = ["full"] }
 tower = "0.5.2"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-tower-sessions = { version = "0.14.0", default-features = false, features = [
+tower-sessions = { version = "0.15.0", default-features = false, features = [
   "signed",
 ] }
 tower-sessions-sqlx-store = { version = "0.15.0", features = ["sqlite"] }


### PR DESCRIPTION
Plus I think we need an upgrade docs for method: `continuously_delete_expired` which seems to be not present anymore. Right?