### PR TITLE
Forward request session to backend (experiment)

### DIFF
--- a/axum-login/src/backend.rs
+++ b/axum-login/src/backend.rs
@@ -5,6 +5,7 @@ use std::{
     hash::Hash,
 };
 
+use crate::tower_sessions::Session;
 use serde::{Deserialize, Serialize};
 
 /// Type alias for the backend user's ID.
@@ -68,6 +69,7 @@ pub trait AuthUser: Debug + Clone + Send + Sync {
 /// use std::collections::HashMap;
 ///
 /// use axum_login::{AuthUser, AuthnBackend, UserId};
+/// use tower_sessions::Session;
 ///
 /// #[derive(Debug, Clone)]
 /// struct User {
@@ -105,6 +107,7 @@ pub trait AuthUser: Debug + Clone + Send + Sync {
 ///     async fn authenticate(
 ///         &self,
 ///         Credentials { user_id }: Self::Credentials,
+///         _: &Session,
 ///     ) -> Result<Option<Self::User>, Self::Error> {
 ///         Ok(self.users.get(&user_id).cloned())
 ///     }
@@ -112,6 +115,7 @@ pub trait AuthUser: Debug + Clone + Send + Sync {
 ///     async fn get_user(
 ///         &self,
 ///         user_id: &UserId<Self>,
+///         _: &Session,
 ///     ) -> Result<Option<Self::User>, Self::Error> {
 ///         Ok(self.users.get(user_id).cloned())
 ///     }
@@ -131,12 +135,14 @@ pub trait AuthnBackend: Clone + Send + Sync {
     fn authenticate(
         &self,
         creds: Self::Credentials,
+        session: &Session,
     ) -> impl Future<Output = Result<Option<Self::User>, Self::Error>> + Send;
 
     /// Gets the user by provided ID from the backend.
     fn get_user(
         &self,
         user_id: &UserId<Self>,
+        session: &Session,
     ) -> impl Future<Output = Result<Option<Self::User>, Self::Error>> + Send;
 }
 
@@ -154,6 +160,7 @@ where
     fn get_user_permissions(
         &self,
         _user: &Self::User,
+        _session: &Session,
     ) -> impl Future<Output = Result<HashSet<Self::Permission>, Self::Error>> + Send {
         async { Ok(HashSet::new()) }
     }
@@ -162,6 +169,7 @@ where
     fn get_group_permissions(
         &self,
         _user: &Self::User,
+        _session: &Session,
     ) -> impl Future<Output = Result<HashSet<Self::Permission>, Self::Error>> + Send {
         async { Ok(HashSet::new()) }
     }
@@ -170,11 +178,12 @@ where
     fn get_all_permissions(
         &self,
         user: &Self::User,
+        session: &Session,
     ) -> impl Future<Output = Result<HashSet<Self::Permission>, Self::Error>> + Send {
         async {
             let mut all_perms = HashSet::new();
-            all_perms.extend(self.get_user_permissions(user).await?);
-            all_perms.extend(self.get_group_permissions(user).await?);
+            all_perms.extend(self.get_user_permissions(user, session).await?);
+            all_perms.extend(self.get_group_permissions(user, session).await?);
             Ok(all_perms)
         }
     }
@@ -185,14 +194,22 @@ where
         &self,
         user: &Self::User,
         perm: Self::Permission,
+        session: &Session,
     ) -> impl Future<Output = Result<bool, Self::Error>> + Send {
-        async move { Ok(self.get_all_permissions(user).await?.contains(&perm)) }
+        async move {
+            Ok(self
+                .get_all_permissions(user, session)
+                .await?
+                .contains(&perm))
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{collections::HashMap, sync::Arc};
+
+    use tower_sessions::MemoryStore;
 
     use super::*;
 
@@ -261,6 +278,7 @@ mod tests {
         async fn authenticate(
             &self,
             user_id: Self::Credentials,
+            _session: &Session,
         ) -> Result<Option<Self::User>, Self::Error> {
             Ok(self.users.get(&user_id).cloned())
         }
@@ -268,6 +286,7 @@ mod tests {
         async fn get_user(
             &self,
             user_id: &UserId<Self>,
+            _session: &Session,
         ) -> Result<Option<Self::User>, Self::Error> {
             Ok(self.users.get(user_id).cloned())
         }
@@ -279,6 +298,7 @@ mod tests {
         async fn get_user_permissions(
             &self,
             user: &Self::User,
+            _session: &Session,
         ) -> Result<HashSet<Self::Permission>, Self::Error> {
             Ok(self
                 .user_permissions
@@ -290,6 +310,7 @@ mod tests {
         async fn get_group_permissions(
             &self,
             user: &Self::User,
+            _session: &Session,
         ) -> Result<HashSet<Self::Permission>, Self::Error> {
             let belongs_to = self
                 .groups
@@ -330,15 +351,21 @@ mod tests {
         let mut backend = TestBackend::new();
         backend.add_user(user.clone(), vec![]);
 
-        let authenticated_user = backend.authenticate(1).await.unwrap();
+        let dummy_session = Session::new(None, Arc::new(MemoryStore::default()), None);
+        let authenticated_user = backend.authenticate(1, &dummy_session).await.unwrap();
         assert_eq!(authenticated_user, Some(user));
     }
 
     #[tokio::test]
     async fn test_authenticate_failure() {
         let backend = TestBackend::new();
+        let dummy_session = Session::new(None, Arc::new(MemoryStore::default()), None);
 
-        assert!(backend.authenticate(1).await.unwrap().is_none());
+        assert!(backend
+            .authenticate(1, &dummy_session)
+            .await
+            .unwrap()
+            .is_none());
     }
 
     #[tokio::test]
@@ -350,7 +377,9 @@ mod tests {
         let mut backend = TestBackend::new();
         backend.add_user(user.clone(), vec![]);
 
-        let retrieved_user = backend.get_user(&1).await.unwrap();
+        let dummy_session = Session::new(None, Arc::new(MemoryStore::default()), None);
+
+        let retrieved_user = backend.get_user(&1, &dummy_session).await.unwrap();
         assert_eq!(retrieved_user, Some(user));
     }
 
@@ -363,7 +392,12 @@ mod tests {
         let mut backend = TestBackend::new();
         backend.add_user(user.clone(), vec!["read".to_string(), "write".to_string()]);
 
-        let permissions = backend.get_user_permissions(&user).await.unwrap();
+        let dummy_session = Session::new(None, Arc::new(MemoryStore::default()), None);
+
+        let permissions = backend
+            .get_user_permissions(&user, &dummy_session)
+            .await
+            .unwrap();
         assert_eq!(
             permissions,
             ["read".to_string(), "write".to_string()]
@@ -399,8 +433,13 @@ mod tests {
         backend.add_user_to_group(admin.clone(), "users".to_string());
         backend.add_user_to_group(admin.clone(), "admins".to_string());
 
+        let dummy_session = Session::new(None, Arc::new(MemoryStore::default()), None);
+
         // User permissions.
-        let user_perms = backend.get_group_permissions(&user).await.unwrap();
+        let user_perms = backend
+            .get_group_permissions(&user, &dummy_session)
+            .await
+            .unwrap();
         assert_eq!(
             user_perms,
             ["read".to_string(), "write".to_string()]
@@ -409,7 +448,10 @@ mod tests {
                 .collect()
         );
 
-        let admin_perms = backend.get_group_permissions(&admin).await.unwrap();
+        let admin_perms = backend
+            .get_group_permissions(&admin, &dummy_session)
+            .await
+            .unwrap();
         assert_eq!(
             admin_perms,
             [
@@ -437,7 +479,12 @@ mod tests {
         );
         backend.add_user_to_group(user.clone(), "users".to_string());
 
-        let permissions = backend.get_all_permissions(&user).await.unwrap();
+        let dummy_session = Session::new(None, Arc::new(MemoryStore::default()), None);
+
+        let permissions = backend
+            .get_all_permissions(&user, &dummy_session)
+            .await
+            .unwrap();
         assert_eq!(
             permissions,
             ["read".to_string(), "write".to_string(), "other".to_string()]
@@ -456,10 +503,18 @@ mod tests {
         let mut backend = TestBackend::new();
         backend.add_user(user.clone(), vec!["read".to_string()]);
 
-        let has_read_perm = backend.has_perm(&user, "read".to_string()).await.unwrap();
+        let dummy_session = Session::new(None, Arc::new(MemoryStore::default()), None);
+
+        let has_read_perm = backend
+            .has_perm(&user, "read".to_string(), &dummy_session)
+            .await
+            .unwrap();
         assert!(has_read_perm);
 
-        let has_delete_perm = backend.has_perm(&user, "delete".to_string()).await.unwrap();
+        let has_delete_perm = backend
+            .has_perm(&user, "delete".to_string(), &dummy_session)
+            .await
+            .unwrap();
         assert!(!has_delete_perm);
     }
 
@@ -472,12 +527,23 @@ mod tests {
         let mut backend = TestBackend::new();
         backend.add_user(user.clone(), vec!["write".to_string(), "read".to_string()]);
 
-        let has_read_and_write_perms = backend.has_perm(&user, "read".to_string()).await.unwrap()
-            && backend.has_perm(&user, "write".to_string()).await.unwrap();
+        let dummy_session = Session::new(None, Arc::new(MemoryStore::default()), None);
+
+        let has_read_and_write_perms = backend
+            .has_perm(&user, "read".to_string(), &dummy_session)
+            .await
+            .unwrap()
+            && backend.has_perm(&user, "write".to_string(), &dummy_session).await.unwrap();
         assert!(has_read_and_write_perms);
 
-        let has_read_and_delete_perms = backend.has_perm(&user, "read".to_string()).await.unwrap()
-            && backend.has_perm(&user, "delete".to_string()).await.unwrap();
+        let has_read_and_delete_perms = backend
+            .has_perm(&user, "read".to_string(), &dummy_session)
+            .await
+            .unwrap()
+            && backend
+                .has_perm(&user, "delete".to_string(), &dummy_session)
+                .await
+                .unwrap();
         assert!(!has_read_and_delete_perms);
     }
 
@@ -490,13 +556,24 @@ mod tests {
         let mut backend = TestBackend::new();
         backend.add_user(user.clone(), vec![]);
 
-        let permissions = backend.get_user_permissions(&user).await.unwrap();
+        let dummy_session = Session::new(None, Arc::new(MemoryStore::default()), None);
+
+        let permissions = backend
+            .get_user_permissions(&user, &dummy_session)
+            .await
+            .unwrap();
         assert!(permissions.is_empty());
 
-        let permissions = backend.get_group_permissions(&user).await.unwrap();
+        let permissions = backend
+            .get_group_permissions(&user, &dummy_session)
+            .await
+            .unwrap();
         assert!(permissions.is_empty());
 
-        let permissions = backend.get_all_permissions(&user).await.unwrap();
+        let permissions = backend
+            .get_all_permissions(&user, &dummy_session)
+            .await
+            .unwrap();
         assert!(permissions.is_empty());
     }
 }

--- a/axum-login/src/lib.rs
+++ b/axum-login/src/lib.rs
@@ -37,6 +37,7 @@
 //! use std::collections::HashMap;
 //!
 //! use axum_login::{AuthUser, AuthnBackend, UserId};
+//! use tower_sessions::Session;
 //!
 //! #[derive(Debug, Clone)]
 //! struct User {
@@ -74,6 +75,7 @@
 //!     async fn authenticate(
 //!         &self,
 //!         Credentials { user_id }: Self::Credentials,
+//!         _: &Session,
 //!     ) -> Result<Option<Self::User>, Self::Error> {
 //!         Ok(self.users.get(&user_id).cloned())
 //!     }
@@ -81,6 +83,7 @@
 //!     async fn get_user(
 //!         &self,
 //!         user_id: &UserId<Self>,
+//!         _: &Session,
 //!     ) -> Result<Option<Self::User>, Self::Error> {
 //!         Ok(self.users.get(user_id).cloned())
 //!     }
@@ -116,6 +119,7 @@
 //! # use std::collections::HashMap;
 //! #
 //! # use axum_login::{AuthUser, AuthnBackend, UserId};
+//! # use tower_sessions::Session;
 //! #
 //! # #[derive(Debug, Clone)]
 //! # struct User {
@@ -153,6 +157,7 @@
 //! #     async fn authenticate(
 //! #         &self,
 //! #         Credentials { user_id }: Self::Credentials,
+//! #         _: &Session,
 //! #     ) -> Result<Option<Self::User>, Self::Error> {
 //! #         Ok(self.users.get(&user_id).cloned())
 //! #     }
@@ -160,6 +165,7 @@
 //! #     async fn get_user(
 //! #         &self,
 //! #         user_id: &UserId<Self>,
+//! #         _: &Session,
 //! #     ) -> Result<Option<Self::User>, Self::Error> {
 //! #         Ok(self.users.get(user_id).cloned())
 //! #     }
@@ -206,6 +212,7 @@
 //! # use std::collections::HashMap;
 //! #
 //! # use axum_login::{AuthUser, AuthnBackend, UserId};
+//! # use tower_sessions::Session;
 //! #
 //! # #[derive(Debug, Clone)]
 //! # struct User {
@@ -243,6 +250,7 @@
 //! #     async fn authenticate(
 //! #         &self,
 //! #         Credentials { user_id }: Self::Credentials,
+//! #         _: &Session,
 //! #     ) -> Result<Option<Self::User>, Self::Error> {
 //! #         Ok(self.users.get(&user_id).cloned())
 //! #     }
@@ -250,6 +258,7 @@
 //! #     async fn get_user(
 //! #         &self,
 //! #         user_id: &UserId<Self>,
+//! #         _: &Session,
 //! #     ) -> Result<Option<Self::User>, Self::Error> {
 //! #         Ok(self.users.get(user_id).cloned())
 //! #     }
@@ -285,6 +294,7 @@
 //!     require::{RedirectHandler, Require},
 //!     AuthUser, AuthnBackend, UserId,
 //! };
+//! use tower_sessions::Session;
 //!
 //! #[derive(Clone, Debug)]
 //! struct User;
@@ -312,11 +322,12 @@
 //!     async fn authenticate(
 //!         &self,
 //!         _: Self::Credentials,
+//!         _: &Session,
 //!     ) -> Result<Option<Self::User>, Self::Error> {
 //!         Ok(Some(User))
 //!     }
 //!
-//!     async fn get_user(&self, _: &UserId<Self>) -> Result<Option<Self::User>, Self::Error> {
+//!     async fn get_user(&self, _: &UserId<Self>, _: &Session) -> Result<Option<Self::User>, Self::Error> {
 //!         Ok(Some(User))
 //!     }
 //! }
@@ -356,6 +367,7 @@
 //! # use std::collections::HashMap;
 //! #
 //! # use axum_login::{AuthUser, AuthnBackend, UserId};
+//! # use tower_sessions::Session;
 //! #
 //! # #[derive(Debug, Clone)]
 //! # struct User {
@@ -393,6 +405,7 @@
 //! #     async fn authenticate(
 //! #         &self,
 //! #         Credentials { user_id }: Self::Credentials,
+//! #         _: &Session,
 //! #     ) -> Result<Option<Self::User>, Self::Error> {
 //! #         Ok(self.users.get(&user_id).cloned())
 //! #     }
@@ -400,6 +413,7 @@
 //! #     async fn get_user(
 //! #         &self,
 //! #         user_id: &UserId<Self>,
+//! #         _: &Session,
 //! #     ) -> Result<Option<Self::User>, Self::Error> {
 //! #         Ok(self.users.get(user_id).cloned())
 //! #     }

--- a/axum-login/src/middleware.rs
+++ b/axum-login/src/middleware.rs
@@ -138,7 +138,7 @@ mod tests {
     };
     use tower::ServiceExt;
     use tower_cookies::cookie;
-    use tower_sessions::SessionManagerLayer;
+    use tower_sessions::{Session, SessionManagerLayer};
     use tower_sessions_sqlx_store::{sqlx::SqlitePool, SqliteStore};
 
     use crate::{AuthManagerLayerBuilder, AuthSession, AuthUser, AuthnBackend, AuthzBackend};
@@ -181,6 +181,7 @@ mod tests {
         async fn authenticate(
             &self,
             _: Self::Credentials,
+            _: &Session,
         ) -> Result<Option<Self::User>, Self::Error> {
             Ok(Some(User))
         }
@@ -188,6 +189,7 @@ mod tests {
         async fn get_user(
             &self,
             _: &<<Backend as AuthnBackend>::User as AuthUser>::Id,
+            _: &Session,
         ) -> Result<Option<Self::User>, Self::Error> {
             Ok(Some(User))
         }
@@ -212,6 +214,7 @@ mod tests {
         async fn get_user_permissions(
             &self,
             _user: &Self::User,
+            _: &Session,
         ) -> Result<HashSet<Self::Permission>, Self::Error> {
             let perms: HashSet<Self::Permission> =
                 HashSet::from_iter(["test.read".into(), "test.write".into()]);

--- a/axum-login/src/require.rs
+++ b/axum-login/src/require.rs
@@ -11,6 +11,7 @@
 //! # use std::collections::HashMap;
 //! #
 //! # use axum_login::{AuthUser, AuthnBackend, UserId};
+//! # use tower_sessions::Session;
 //! #
 //! # #[derive(Debug, Clone)]
 //! # struct User {
@@ -48,6 +49,7 @@
 //! #     async fn authenticate(
 //! #         &self,
 //! #         Credentials { user_id }: Self::Credentials,
+//! #         _: &Session,
 //! #     ) -> Result<Option<Self::User>, Self::Error> {
 //! #         Ok(self.users.get(&user_id).cloned())
 //! #     }
@@ -55,6 +57,7 @@
 //! #     async fn get_user(
 //! #         &self,
 //! #         user_id: &UserId<Self>,
+//! #         _: &Session,
 //! #     ) -> Result<Option<Self::User>, Self::Error> {
 //! #         Ok(self.users.get(user_id).cloned())
 //! #     }
@@ -107,6 +110,7 @@
 //!     require::{PermissionsPredicate, RedirectHandler, Require},
 //!     AuthUser, AuthnBackend, AuthzBackend, UserId,
 //! };
+//! use tower_sessions::Session;
 //!
 //! #[derive(Clone, Debug)]
 //! struct User;
@@ -137,11 +141,12 @@
 //!     async fn authenticate(
 //!         &self,
 //!         _: Self::Credentials,
+//!         _: &Session,
 //!     ) -> Result<Option<Self::User>, Self::Error> {
 //!         Ok(Some(User))
 //!     }
 //!
-//!     async fn get_user(&self, _: &UserId<Self>) -> Result<Option<Self::User>, Self::Error> {
+//!     async fn get_user(&self, _: &UserId<Self>, _: &Session) -> Result<Option<Self::User>, Self::Error> {
 //!         Ok(Some(User))
 //!     }
 //! }
@@ -168,6 +173,7 @@
 //!     require::{Decision, Require},
 //!     AuthSession, AuthUser, AuthnBackend, UserId,
 //! };
+//! use tower_sessions::Session;
 //!
 //! #[derive(Clone, Debug)]
 //! struct User;
@@ -195,11 +201,12 @@
 //!     async fn authenticate(
 //!         &self,
 //!         _: Self::Credentials,
+//!         _: &Session,
 //!     ) -> Result<Option<Self::User>, Self::Error> {
 //!         Ok(Some(User))
 //!     }
 //!
-//!     async fn get_user(&self, _: &UserId<Self>) -> Result<Option<Self::User>, Self::Error> {
+//!     async fn get_user(&self, _: &UserId<Self>, _: &Session) -> Result<Option<Self::User>, Self::Error> {
 //!         Ok(Some(User))
 //!     }
 //! }
@@ -405,7 +412,7 @@ mod tests {
     };
     use tower::ServiceExt;
     use tower_cookies::cookie;
-    use tower_sessions::SessionManagerLayer;
+    use tower_sessions::{Session, SessionManagerLayer};
     use tower_sessions_sqlx_store::{sqlx::SqlitePool, SqliteStore};
 
     use crate::{
@@ -443,7 +450,11 @@ mod tests {
         let Some(user) = auth_session.user().await else {
             return Decision::Unauthenticated;
         };
-        let Ok(u_perms) = auth_session.backend().get_user_permissions(&user).await else {
+        let Ok(u_perms) = auth_session
+            .backend()
+            .get_user_permissions(&user, &auth_session.session().await)
+            .await
+        else {
             return Decision::Unauthorized;
         };
 
@@ -492,6 +503,7 @@ mod tests {
         async fn authenticate(
             &self,
             _: Self::Credentials,
+            _session: &Session,
         ) -> Result<Option<Self::User>, Self::Error> {
             Ok(Some(User))
         }
@@ -499,6 +511,7 @@ mod tests {
         async fn get_user(
             &self,
             _: &<<TestBackend as AuthnBackend>::User as AuthUser>::Id,
+            _session: &Session,
         ) -> Result<Option<Self::User>, Self::Error> {
             Ok(Some(User))
         }
@@ -523,6 +536,7 @@ mod tests {
         async fn get_user_permissions(
             &self,
             _user: &Self::User,
+            _session: &Session,
         ) -> Result<HashSet<Self::Permission>, Self::Error> {
             let perms: HashSet<Self::Permission> =
                 HashSet::from_iter(["test.read".into(), "test.write".into()]);

--- a/axum-login/src/require/builder.rs
+++ b/axum-login/src/require/builder.rs
@@ -45,6 +45,7 @@
 //!     require::{RedirectHandler, Require},
 //!     AuthUser, AuthnBackend, UserId,
 //! };
+//! use tower_sessions::Session;
 //!
 //! #[derive(Clone, Debug)]
 //! struct User;
@@ -72,11 +73,12 @@
 //!     async fn authenticate(
 //!         &self,
 //!         _: Self::Credentials,
+//!         _: &Session,
 //!     ) -> Result<Option<Self::User>, Self::Error> {
 //!         Ok(Some(User))
 //!     }
 //!
-//!     async fn get_user(&self, _: &UserId<Self>) -> Result<Option<Self::User>, Self::Error> {
+//!     async fn get_user(&self, _: &UserId<Self>, _: &Session) -> Result<Option<Self::User>, Self::Error> {
 //!         Ok(Some(User))
 //!     }
 //! }
@@ -120,6 +122,7 @@ use crate::{
 ///     require::{RedirectHandler, Require, RequireBuilder},
 ///     AuthUser, AuthnBackend, UserId,
 /// };
+/// use tower_sessions::Session;
 ///
 /// #[derive(Clone, Debug)]
 /// struct User;
@@ -147,11 +150,12 @@ use crate::{
 ///     async fn authenticate(
 ///         &self,
 ///         _: Self::Credentials,
+///         _: &Session,
 ///     ) -> Result<Option<Self::User>, Self::Error> {
 ///         Ok(Some(User))
 ///     }
 ///
-///     async fn get_user(&self, _: &UserId<Self>) -> Result<Option<Self::User>, Self::Error> {
+///     async fn get_user(&self, _: &UserId<Self>, _: &Session) -> Result<Option<Self::User>, Self::Error> {
 ///         Ok(Some(User))
 ///     }
 /// }
@@ -302,6 +306,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use tower_sessions::Session;
+
     use super::*;
     use crate::{require::Decision, AuthSession, AuthUser};
 
@@ -331,11 +337,16 @@ mod tests {
         async fn authenticate(
             &self,
             _: Self::Credentials,
+            _session: &Session,
         ) -> Result<Option<Self::User>, Self::Error> {
             Ok(Some(TestUser))
         }
 
-        async fn get_user(&self, _: &i64) -> Result<Option<Self::User>, Self::Error> {
+        async fn get_user(
+            &self,
+            _: &i64,
+            _session: &Session,
+        ) -> Result<Option<Self::User>, Self::Error> {
             Ok(Some(TestUser))
         }
     }

--- a/axum-login/src/require/handler.rs
+++ b/axum-login/src/require/handler.rs
@@ -86,6 +86,7 @@ impl<ReqInBody> ResponseHandler<ReqInBody> for InternalErrorFallback {
 ///     require::{RedirectHandler, Require},
 ///     AuthUser, AuthnBackend, UserId,
 /// };
+/// use tower_sessions::Session;
 ///
 /// #[derive(Clone, Debug)]
 /// struct User;
@@ -113,11 +114,12 @@ impl<ReqInBody> ResponseHandler<ReqInBody> for InternalErrorFallback {
 ///     async fn authenticate(
 ///         &self,
 ///         _: Self::Credentials,
+///         _: &Session,
 ///     ) -> Result<Option<Self::User>, Self::Error> {
 ///         Ok(Some(User))
 ///     }
 ///
-///     async fn get_user(&self, _: &UserId<Self>) -> Result<Option<Self::User>, Self::Error> {
+///     async fn get_user(&self, _: &UserId<Self>, _: &Session) -> Result<Option<Self::User>, Self::Error> {
 ///         Ok(Some(User))
 ///     }
 /// }
@@ -214,6 +216,7 @@ where
 ///     require::{Require, SimpleResponseHandler},
 ///     AuthUser, AuthnBackend, UserId,
 /// };
+/// use tower_sessions::Session;
 ///
 /// #[derive(Clone, Debug)]
 /// struct User;
@@ -241,11 +244,12 @@ where
 ///     async fn authenticate(
 ///         &self,
 ///         _: Self::Credentials,
+///         _: &Session,
 ///     ) -> Result<Option<Self::User>, Self::Error> {
 ///         Ok(Some(User))
 ///     }
 ///
-///     async fn get_user(&self, _: &UserId<Self>) -> Result<Option<Self::User>, Self::Error> {
+///     async fn get_user(&self, _: &UserId<Self>, _: &Session) -> Result<Option<Self::User>, Self::Error> {
 ///         Ok(Some(User))
 ///     }
 /// }

--- a/axum-login/src/require/predicate.rs
+++ b/axum-login/src/require/predicate.rs
@@ -99,6 +99,7 @@ pub enum PermissionMatch {
 ///     require::{PermissionMatch, PermissionsPredicate, Require},
 ///     AuthUser, AuthnBackend, AuthzBackend, UserId,
 /// };
+/// use tower_sessions::Session;
 ///
 /// #[derive(Clone, Debug)]
 /// struct User;
@@ -129,11 +130,12 @@ pub enum PermissionMatch {
 ///     async fn authenticate(
 ///         &self,
 ///         _: Self::Credentials,
+///         _: &Session,
 ///     ) -> Result<Option<Self::User>, Self::Error> {
 ///         Ok(Some(User))
 ///     }
 ///
-///     async fn get_user(&self, _: &UserId<Self>) -> Result<Option<Self::User>, Self::Error> {
+///     async fn get_user(&self, _: &UserId<Self>, _: &Session) -> Result<Option<Self::User>, Self::Error> {
 ///         Ok(Some(User))
 ///     }
 /// }
@@ -208,7 +210,11 @@ where
                 return Decision::Unauthenticated;
             };
 
-            match auth_session.backend().get_all_permissions(&user).await {
+            match auth_session
+                .backend()
+                .get_all_permissions(&user, &auth_session.session().await)
+                .await
+            {
                 Ok(user_permissions) => {
                     let allow = match match_mode {
                         PermissionMatch::Any => required_permissions
@@ -278,11 +284,12 @@ mod tests {
         async fn authenticate(
             &self,
             _: Self::Credentials,
+            _: &Session,
         ) -> Result<Option<Self::User>, Self::Error> {
             Ok(Some(TestUser))
         }
 
-        async fn get_user(&self, _: &i64) -> Result<Option<Self::User>, Self::Error> {
+        async fn get_user(&self, _: &i64, _: &Session) -> Result<Option<Self::User>, Self::Error> {
             Ok(Some(TestUser))
         }
     }
@@ -293,6 +300,7 @@ mod tests {
         async fn get_all_permissions(
             &self,
             _user: &Self::User,
+            _: &Session,
         ) -> Result<HashSet<Self::Permission>, Self::Error> {
             Err(TestError)
         }

--- a/axum-login/src/require/service.rs
+++ b/axum-login/src/require/service.rs
@@ -295,11 +295,12 @@ mod tests {
         async fn authenticate(
             &self,
             _: Self::Credentials,
+            _: &Session,
         ) -> Result<Option<Self::User>, Self::Error> {
             Ok(Some(TestUser))
         }
 
-        async fn get_user(&self, _: &i64) -> Result<Option<Self::User>, Self::Error> {
+        async fn get_user(&self, _: &i64, _: &Session) -> Result<Option<Self::User>, Self::Error> {
             Ok(Some(TestUser))
         }
     }

--- a/axum-login/src/session.rs
+++ b/axum-login/src/session.rs
@@ -97,6 +97,11 @@ impl<Backend: AuthnBackend> AuthSession<Backend> {
         self.inner.lock().await.user.clone()
     }
 
+    /// Returns the underlying session.
+    pub async fn session(&self) -> Session {
+        self.inner.lock().await.session.clone()
+    }
+
     /// Verifies the provided credentials via the backend returning the
     /// authenticated user if valid and otherwise `None`.
     #[tracing::instrument(level = "debug", skip_all, fields(user.id), ret, err)]
@@ -104,9 +109,10 @@ impl<Backend: AuthnBackend> AuthSession<Backend> {
         &self,
         creds: Backend::Credentials,
     ) -> Result<Option<Backend::User>, Error<Backend>> {
+        let session = self.session().await;
         let result = self
             .backend
-            .authenticate(creds)
+            .authenticate(creds, &session)
             .await
             .map_err(Error::Backend);
 
@@ -168,7 +174,10 @@ impl<Backend: AuthnBackend> AuthSession<Backend> {
         let mut data: Data<_> = session.get(data_key).await?.unwrap_or_default();
 
         let mut user = if let Some(ref user_id) = data.user_id {
-            backend.get_user(user_id).await.map_err(Error::Backend)?
+            backend
+                .get_user(user_id, &session)
+                .await
+                .map_err(Error::Backend)?
         } else {
             None
         };
@@ -219,8 +228,8 @@ mod tests {
             type Credentials = MockCredentials;
             type Error = MockError;
 
-            async fn authenticate(&self, creds: MockCredentials) -> Result<Option<MockUser>, MockError>;
-            async fn get_user(&self, user_id: &i64) -> Result<Option<MockUser>, MockError>;
+            async fn authenticate(&self, creds: MockCredentials, _session: &Session) -> Result<Option<MockUser>, MockError>;
+            async fn get_user(&self, user_id: &i64, _session: &Session) -> Result<Option<MockUser>, MockError>;
 
         }
     }
@@ -268,9 +277,9 @@ mod tests {
 
         mock_backend
             .expect_authenticate()
-            .with(eq(creds.clone()))
+            .with(eq(creds.clone()), always())
             .times(1)
-            .returning(move |_| Ok(Some(mock_user.clone())));
+            .returning(move |_, _| Ok(Some(mock_user.clone())));
 
         let store = Arc::new(MemoryStore::default());
 
@@ -298,9 +307,9 @@ mod tests {
 
         mock_backend
             .expect_authenticate()
-            .with(eq(bad_creds.clone()))
+            .with(eq(bad_creds.clone()), always())
             .times(1)
-            .returning(|_| Ok(None));
+            .returning(|_, _| Ok(None));
 
         let store = Arc::new(MemoryStore::default());
 
@@ -392,9 +401,9 @@ mod tests {
 
         mock_backend
             .expect_get_user()
-            .with(eq(mock_user.id))
+            .with(eq(mock_user.id), always())
             .times(1)
-            .returning(move |_| Ok(Some(mock_user.clone())));
+            .returning(move |_, _| Ok(Some(mock_user.clone())));
 
         let store = Arc::new(MemoryStore::default());
         let session = Session::new(None, store.clone(), None);
@@ -425,9 +434,9 @@ mod tests {
 
         mock_backend
             .expect_get_user()
-            .with(eq(mock_user.id))
+            .with(eq(mock_user.id), always())
             .times(1)
-            .returning(move |_| Ok(Some(mock_user.clone())));
+            .returning(move |_, _| Ok(Some(mock_user.clone())));
 
         let store = Arc::new(MemoryStore::default());
         let session = Session::new(None, store.clone(), None);

--- a/examples/permissions/src/users.rs
+++ b/examples/permissions/src/users.rs
@@ -5,6 +5,7 @@ use password_auth::verify_password;
 use serde::{Deserialize, Serialize};
 use sqlx::{FromRow, SqlitePool};
 use tokio::task;
+use tower_sessions::Session;
 
 #[derive(Clone, Serialize, Deserialize, FromRow)]
 pub struct User {
@@ -75,6 +76,7 @@ impl AuthnBackend for Backend {
     async fn authenticate(
         &self,
         creds: Self::Credentials,
+        _: &Session,
     ) -> Result<Option<Self::User>, Self::Error> {
         let user: Option<Self::User> = sqlx::query_as("select * from users where username = ? ")
             .bind(creds.username)
@@ -91,7 +93,11 @@ impl AuthnBackend for Backend {
         .await?
     }
 
-    async fn get_user(&self, user_id: &UserId<Self>) -> Result<Option<Self::User>, Self::Error> {
+    async fn get_user(
+        &self,
+        user_id: &UserId<Self>,
+        _: &Session,
+    ) -> Result<Option<Self::User>, Self::Error> {
         let user = sqlx::query_as("select * from users where id = ?")
             .bind(user_id)
             .fetch_optional(&self.db)
@@ -120,6 +126,7 @@ impl AuthzBackend for Backend {
     async fn get_group_permissions(
         &self,
         user: &Self::User,
+        _: &Session,
     ) -> Result<HashSet<Self::Permission>, Self::Error> {
         let permissions: Vec<Self::Permission> = sqlx::query_as(
             r#"

--- a/examples/sqlite/src/users.rs
+++ b/examples/sqlite/src/users.rs
@@ -3,6 +3,7 @@ use password_auth::verify_password;
 use serde::{Deserialize, Serialize};
 use sqlx::{FromRow, SqlitePool};
 use tokio::task;
+use tower_sessions::Session;
 
 #[derive(Clone, Serialize, Deserialize, FromRow)]
 pub struct User {
@@ -75,6 +76,7 @@ impl AuthnBackend for Backend {
     async fn authenticate(
         &self,
         creds: Self::Credentials,
+        _: &Session,
     ) -> Result<Option<Self::User>, Self::Error> {
         let user: Option<Self::User> = sqlx::query_as("select * from users where username = ? ")
             .bind(creds.username)
@@ -91,7 +93,11 @@ impl AuthnBackend for Backend {
         .await?
     }
 
-    async fn get_user(&self, user_id: &UserId<Self>) -> Result<Option<Self::User>, Self::Error> {
+    async fn get_user(
+        &self,
+        user_id: &UserId<Self>,
+        _: &Session,
+    ) -> Result<Option<Self::User>, Self::Error> {
         let user = sqlx::query_as("select * from users where id = ?")
             .bind(user_id)
             .fetch_optional(&self.db)


### PR DESCRIPTION
A bit of an experiment, as I found myself missing access to the underlying session when handling OAuth and JWTs. Specifically, in my `Backend`, I fetch a JWT in the `authenticate` method which contains access controls I want to keep alive with the session, aka. user permissions. These permissions would then be needed in the `AuthzBackend`, which would require some sort of session permanence. I could have this separatly, however it seems much cleaner to store it directly in the session data. Any other solutions are more than welcome!

Enables the backend to use the session for non-permanent data, which could be handy for e.g. backends based on OAuth 
in which the initial authentication contains permission or other non-permanent data we want to keep around with the session.