### PR TITLE
Change axum-login dependency to GitHub source

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Example (builder only, no macros):
 
 ```toml
 [dependencies]
-axum-login = { version = "0.18.0", default-features = false, features = ["require-builder"] }
+axum-login = { version = "0.18.0", default-features = false, features = ["require-builder"], git = "https://github.com/maxcountryman/axum-login.git" }
 ```
 
 ## 🦺 Safety


### PR DESCRIPTION
Updated axum-login dependency to use GitHub repository.

Currently on crates.io it doesn't track the current new changes for the introduction of the features require-builder and macros.

